### PR TITLE
Add specification HMAC-SHA384 init function

### DIFF
--- a/Primitive/Keyless/Hash/HMAC.cry
+++ b/Primitive/Keyless/Hash/HMAC.cry
@@ -8,7 +8,7 @@
  * This is a simple implementation of HMAC with SHA-384
  */
 
-module hmac where
+module HMAC where
 
 import SHA512Imp
 
@@ -24,14 +24,14 @@ key_init key =
               then key # (zero : [inf][8])
               else (hash_key_le key) # (zero : [inf][8]))
 
-type HmacState = { i_ctx  : SHA512State
+type HMACState = { i_ctx  : SHA512State
                  , o_ctx  : SHA512State
                  , md_ctx : SHA512State
                  }
 
 // HMAC-SHA384 init function
-HmacInit : {key_size} (fin key_size) => [key_size][8] -> HmacState
-HmacInit key =
+HMACInit : {key_size} (fin key_size) => [key_size][8] -> HMACState
+HMACInit key =
   { i_ctx  = i_state
   , o_ctx  = SHA512Update SHA384Init opad
   , md_ctx = i_state

--- a/Primitive/Keyless/Hash/SHA512Imp.cry
+++ b/Primitive/Keyless/Hash/SHA512Imp.cry
@@ -12,7 +12,7 @@
  * http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA512.pdf and
  * http://csrc.nist.gov/groups/ST/toolkit/documents/Examples/SHA384.pdf
  */
-module SHA512 where
+module SHA512Imp where
 
 /*
  * SHA512 Functions : Section 4.1.3

--- a/Primitive/Keyless/Hash/hmac.cry
+++ b/Primitive/Keyless/Hash/hmac.cry
@@ -1,0 +1,42 @@
+/*
+   Copyright (c) 2020, Galois Inc.
+   www.cryptol.net
+   You can freely use this source code for educational purposes.
+*/
+
+/*
+ * This is a simple implementation of HMAC with SHA-384
+ */
+
+module hmac where
+
+import SHA512Imp
+
+// Hash `key` and convert the digest to little endian
+hash_key_le : {key_size} (fin key_size) => [key_size][8] -> [48][8]
+hash_key_le key =
+  reverse (split`{48} (join (reverse (split`{each=64} (SHA384Imp key)))))
+
+// Pad or hash `key`, depending on its length, until it is 128 bytes long
+key_init : {key_size} (fin key_size) => [key_size][8] -> [128][8]
+key_init key =
+  take`{128} (if `key_size <= 128
+              then key # (zero : [inf][8])
+              else (hash_key_le key) # (zero : [inf][8]))
+
+type HmacState = { i_ctx  : SHA512State
+                 , o_ctx  : SHA512State
+                 , md_ctx : SHA512State
+                 }
+
+// HMAC-SHA384 init function
+HmacInit : {key_size} (fin key_size) => [key_size][8] -> HmacState
+HmacInit key =
+  { i_ctx  = i_state
+  , o_ctx  = SHA512Update SHA384Init opad
+  , md_ctx = i_state
+  }
+  where key'    = key_init key
+        ipad    = [ k ^ 0x36 | k <- key' ]
+        opad    = [ k ^ 0x5c | k <- key' ]
+        i_state = SHA512Update SHA384Init ipad


### PR DESCRIPTION
This PR adds a specification for the HMAC init function using SHA384