### PR TITLE
add basic test/ci script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: Cryptol
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/galoisinc/cryptol:nightly
+      options: --user root
+    steps:
+    - name: Installing dependencies..
+      run: |
+        # Sync repos
+        apt update
+        # Install git
+        apt install -y git
+        if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
+          apt install -y git
+        elif apt list --installed 2>/dev/null | grep -q "git.*"; then
+          true
+        else
+          exit 255
+        fi
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: What cryptol version is installed?
+      run: cryptol --version
+    - name: Check Cryptol Files
+      run: bash scripts/load_all_cry_files.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,11 @@ jobs:
     steps:
     - name: Installing dependencies..
       run: |
-        # Sync repos
         apt update
-        # Install git
         apt install -y git
-        if ! apt list --installed 2>/dev/null | grep -q "git.*"; then
-          apt install -y git
-        elif apt list --installed 2>/dev/null | grep -q "git.*"; then
-          true
-        else
-          exit 255
-        fi
     - name: Checkout
       uses: actions/checkout@v2
-    - name: What cryptol version is installed?
+    - name: Cryptol Version
       run: cryptol --version
     - name: Check Cryptol Files
       run: bash scripts/load_all_cry_files.sh

--- a/scripts/load_all_cry_files.sh
+++ b/scripts/load_all_cry_files.sh
@@ -1,0 +1,53 @@
+#! /bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pushd $DIR/.. > /dev/null
+
+
+
+
+NUM_FILES=0
+NUM_FAILS=0
+FAILS=()
+SCRIPT=$(mktemp)
+
+load_cry_files() {
+    for FILE in "$1"/*;do
+        if [ -d "$FILE" ];then
+            load_cry_files "$FILE"
+        elif [[ -f "$FILE" && "$FILE" == *.cry ]]; then
+          NUM_FILES=$(($NUM_FILES+1))
+          echo ":load $FILE" > $SCRIPT
+          cryptol -e --batch $SCRIPT
+          if (( $? != 0 )); then
+            NUM_FAILS=$(($NUM_FAILS+1))
+            FAILS+=("$FILE")
+          fi
+        fi
+    done
+}
+
+load_cry_files "."
+
+rm $SCRIPT
+
+
+echo ""
+echo "=== Done checking $NUM_FILES Cryptol files ==="
+
+if (( $NUM_FAILS != 0 ))
+then
+  echo "$NUM_FAILS cryptol-spec files failed to load:"
+  for FILE in "${FAILS[@]}"
+  do
+      echo "  $FILE"
+  done
+  exit 1
+else
+  echo "All cryptol-spec files loaded successfully."
+  exit 0
+fi
+
+
+popd > /dev/null


### PR DESCRIPTION
This PR adds a script which attempts to load all Cryptol files in the repository, and returns a non-zero exit code if any fail. It is run using the `ghcr.io/galoisinc/cryptol:nightly` docker image. There's obviously a lot more that _could_ be done in the CI/testing space, but this seems like a potentially useful first step.

At present (on my machine at least), this script ends with the following output (omitting all the Cryptol messages that are printed during loading):
```
=== Done checking 150 Cryptol files ===
35 cryptol-spec files failed to load:
  ./McEliece_KEM/high-level/Decapsulation.cry
  ./McEliece_KEM/high-level/Encapsulation.cry
  ./McEliece_KEM/high-level/Gauss.cry
  ./McEliece_KEM/high-level/Key_Generation.cry
  ./McEliece_KEM/high-level/Shared.cry
  ./McEliece_KEM/high-level/decrypt.cry
  ./McEliece_KEM/high-level/driver.cry
  ./McEliece_KEM/low-level/benes.cry
  ./McEliece_KEM/low-level/decrypt.cry
  ./McEliece_KEM/low-level/decrypt_helpers.cry
  ./McEliece_KEM/low-level/driver.cry
  ./McEliece_KEM/low-level/encrypt.cry
  ./McEliece_KEM/low-level/gf.cry
  ./McEliece_KEM/low-level/operations.cry
  ./McEliece_KEM/low-level/util.cry
  ./McEliece_KEM/spec/Types.cry
  ./Primitive/Asymmetric/Signature/DSA/p1024_sha1.cry
  ./Primitive/Asymmetric/Signature/DSA/p2048_q224.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round1/DilithiumBitVec.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round1/DilithiumInteger.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round1/DilithiumMedium.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round2/DilithiumMedium.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round2/DilithiumParameterized.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round2/DilithiumRecommended.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round2/DilithiumVeryhigh.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Round2/DilithiumWeak.cry
  ./Primitive/Asymmetric/Signature/Dilithium/Utils.cry
  ./Primitive/Asymmetric/Signature/ECDSA/ECDSA_sign_tests.cry
  ./Primitive/Asymmetric/Signature/trash/DilithiumBv.cry
  ./Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
  ./Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
  ./Primitive/Symmetric/Cipher/Block/KATAN.cry
  ./Primitive/Symmetric/Cipher/Block/SHACAL.cry
  ./Primitive/Symmetric/KDF/HKDF256.cry
  ./Primitive/Symmetric/MAC/HMAC.cry
```