### PR TITLE
skip nightly CI for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
     branches:
       - master
-  schedule:
-    - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
-  workflow_dispatch:
+#  schedule:
+#    - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
+#  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
While things are being worked on having
nightly reminders that things are still broken is
unhelpful noise. When we get to the CI passing,
nightly builds can be enabled again to help us
spot if changes to Cryptol have broken
things here.