### PR TITLE
Fix Kyber KEM

### DIFF
--- a/Primitive/Asymmetric/Cipher/Kyber/3.01/specification.tex
+++ b/Primitive/Asymmetric/Cipher/Kyber/3.01/specification.tex
@@ -777,7 +777,7 @@ we define key generation, encapsulation, and decapsulation of \KyberCCAKEM.
 \begin{code}
   // We make the random message m explicit
   CEnc : ([12*k*n/8+32]Byte, [32]Byte) -> ([d_u*k*n/8+d_v*n/8]Byte, [inf]Byte)
-  CEnc (pk, m) = (c,K) where
+  CEnc (pk, m) = (c, map reverse K) where
     m' = H(m) // Cryptol warns about shadowing
     (KBar,r) = G(m'#H(pk))
     c = Enc(pk,m',r)
@@ -809,8 +809,7 @@ we define key generation, encapsulation, and decapsulation of \KyberCCAKEM.
 
 \begin{code}
   CDec : ([d_u*k*n/8+d_v*n/8]Byte,[24*k*n/8+96]Byte) -> [inf]Byte
-  CDec (c,sk) = if (c == c') then KDF(KBar'#H(c))
-                             else KDF(z#H(c))
+  CDec (c,sk) = map reverse K
     where
       sk' = sk@@[0 .. 12*k*n/8 - 1] //We make the first portion explicit
       pk = sk@@[12*k*n/8 .. 24*k*n/8+32 - 1]
@@ -819,6 +818,8 @@ we define key generation, encapsulation, and decapsulation of \KyberCCAKEM.
       m' = Dec(sk',c)
       (KBar', r') = G(m'#h)
       c' = Enc(pk,m',r')
+      K = if (c == c') then KDF(KBar'#H(c))
+                       else KDF(z#H(c))
 
 
   CorrectnessKEM : ([32]Byte, [32]Byte, [32]Byte) -> Bit

--- a/Primitive/Asymmetric/Cipher/Kyber/3.01/specification.tex
+++ b/Primitive/Asymmetric/Cipher/Kyber/3.01/specification.tex
@@ -775,7 +775,10 @@ we define key generation, encapsulation, and decapsulation of \KyberCCAKEM.
 \end{algorithm}
 
 \begin{code}
-  // We make the random message m explicit
+  // We make the random message m explicit.
+  // The output is reversed as a consequence of the current
+  // implementation of the BytesToBits Cryptol function that considers
+  // the rightmost bit of a byte to be the least significant.
   CEnc : ([12*k*n/8+32]Byte, [32]Byte) -> ([d_u*k*n/8+d_v*n/8]Byte, [inf]Byte)
   CEnc (pk, m) = (c, map reverse K) where
     m' = H(m) // Cryptol warns about shadowing
@@ -808,6 +811,9 @@ we define key generation, encapsulation, and decapsulation of \KyberCCAKEM.
 \end{algorithm}
 
 \begin{code}
+  // The output is reversed as a consequence of the current
+  // implementation of the BytesToBits Cryptol function that considers
+  // the rightmost bit of a byte to be the least significant.
   CDec : ([d_u*k*n/8+d_v*n/8]Byte,[24*k*n/8+96]Byte) -> [inf]Byte
   CDec (c,sk) = map reverse K
     where


### PR DESCRIPTION
This PR changes the behavior of Kyber's KEM.Enc and KEM.Dec to output each key byte in reverse order.
As a result:
- The specs now pass the known-answer tests
- The KEM Correctness property passes on random inputs

The solution is not ideal because it slightly deviates from the actual specs but it solves the issue for now. Perhaps a better solution is to modify `BitsToBytes` to account for the reverse ordering.

Resolves #55 