### PR TITLE
Add Beta Parameter to Falcon

### DIFF
--- a/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_1024.cry
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_1024.cry
@@ -12,6 +12,7 @@ submodule falcon_inst = spec2
     sigma = 168.388571447
     sigma_min = 1.298280334
     sigma_max = 1.8205
+    beta = 70265242
 
     Omega_phi = [
         (1.0, 0.0),

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_512.cry
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_512.cry
@@ -12,6 +12,7 @@ submodule falcon_inst = spec2
     sigma = 165.736617183
     sigma_min = 1.277833697
     sigma_max = 1.8205
+    beta = 34034726
 
     Omega_phi = [
         (1, 0),

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
@@ -1446,6 +1446,8 @@ Formally, given a private key \sk and a message \msg, the signer uses \sk to sig
 \end{algorithm}
 
 \begin{code}
+  // The bound floor(beta^2) is a parameter of the system
+  // and not an argument of the function.
   type signature = ([320], [slen])
   Sign : {len} (fin len) => ([len], privateKey, [320]) -> signature
   Sign(m, sk, _r) = sig where 
@@ -1952,6 +1954,8 @@ The specification of the signature verification is given in \longverify.
 \end{algorithm}
 
 \begin{code}
+  // The bound floor(beta^2) is a parameter of the system
+  // and not an argument of the function.
   Verify : {len} (fin len) => ([len], signature, publicKey) -> Bit
   Verify(m, sig, pk) = 
     if s2 == zero then

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
@@ -1447,8 +1447,8 @@ Formally, given a private key \sk and a message \msg, the signer uses \sk to sig
 
 \begin{code}
   type signature = ([320], [slen])
-  Sign : {len} (fin len) => ([len], privateKey, Integer, [320]) -> signature
-  Sign(m, sk, beta, _r) = sig where 
+  Sign : {len} (fin len) => ([len], privateKey, [320]) -> signature
+  Sign(m, sk, _r) = sig where 
     (_, Bhat, T) = sk
     c = HashToPoint`{q,_k}(_r#m)
     [[FFTg,FFT_f],[FFTG,FFT_F]] = Bhat // Bhat stores them in FFT repr
@@ -1952,8 +1952,8 @@ The specification of the signature verification is given in \longverify.
 \end{algorithm}
 
 \begin{code}
-  Verify : {len} (fin len) => ([len], signature, publicKey, Integer) -> Bit
-  Verify(m, sig, pk, beta) = 
+  Verify : {len} (fin len) => ([len], signature, publicKey) -> Bit
+  Verify(m, sig, pk) = 
     if s2 == zero then
       0
     else if norm_sq`{2,_k}([s1',s2']) < (fromInteger beta) then
@@ -2379,6 +2379,7 @@ We specify two sets of parameters that address security levels I and V as define
   parameter
     sigma_min : Float64
     sigma_max : Float64
+    beta : Integer
 \end{code}
 
 \tprcomment{I commented the paragraph on the acceptance bound}


### PR DESCRIPTION
The FALCON specifications define a threshold beta^2 that is used by the Signing and Verification algorithms. Previously the threshold was part of the input to the algorithms although it should be fixed. This PR fixes this.

Closes #59.