### PR TITLE
aes-gcm: fix decryption bug, add properties #46

### DIFF
--- a/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
@@ -18,9 +18,7 @@ property GCM_AE_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ vali
         dec = GCM_AD `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt} zero zero ct [] tag
         expected_ct = []
         expected_tag = 0x58e2fccefa7e3061367f1d57a4e7455a
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False
+        valid_dec = dec.valid && (dec.pt == pt)
 
 property GCM_AE_test_vector_1 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
@@ -33,9 +31,7 @@ property GCM_AE_test_vector_1 =
         expected_tag = 0xab6e47d42cec13bdf53a67b21257bddf : [128]
         (ct, tag) = GCM_AE `{K=128, IV=96} {E=AES::encrypt} key iv pt aad
         dec = GCM_AD `{K=128, IV=96} {E=AES::encrypt} key iv ct aad tag
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False
+        valid_dec = dec.valid && (dec.pt == pt)
 
 property GCM_AE_test_vector_2 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
@@ -48,9 +44,7 @@ property GCM_AE_test_vector_2 =
         expected_tag = 0x4d5c2af327cd64a62cf35abd2ba6fab4 : [128]
         (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
         dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False
+        valid_dec = dec.valid && (dec.pt == pt)
 
 property GCM_AE_test_vector_3 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
@@ -63,9 +57,7 @@ property GCM_AE_test_vector_3 =
         expected_tag = 0x5bc94fbc3221a5db94fae95ae7121a47
         (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
         dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False
+        valid_dec = dec.valid && (dec.pt == pt)
 
 // A test case from aesgcmtest.c
 property GCM_AE_test_vector_4 =
@@ -79,12 +71,10 @@ property GCM_AE_test_vector_4 =
         expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
         (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
         dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False
+        valid_dec = dec.valid && (dec.pt == pt)
 
 property GCM_AE_invalid_test_vector =
-    ct == expected_ct /\ tag == expected_tag /\ ~valid_dec
+    ct == expected_ct /\ tag == expected_tag /\ ~dec.valid
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
         iv    = 0x99aa3e68ed8173a0eed06684 : [96]
@@ -95,6 +85,3 @@ property GCM_AE_invalid_test_vector =
         invalid_tag  = 0x67ba0510262ae487d737ee6298f77888
         (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
         dec = GCM_AD {E=AES::encrypt} key iv ct aad invalid_tag
-        valid_dec = case dec of
-            Some actual_pt -> pt == actual_pt
-            None -> False

--- a/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
@@ -1,37 +1,100 @@
 
 // Cryptol AES GCM test vectors
-// Copyright (c) 2010-2018, Galois Inc.
+// Copyright (c) 2010-2024, Galois Inc.
 // www.cryptol.net
 // Author: Ajay Kumar Eeralla
 
-//Test vectors from http://luca-giuzzi.unibs.it/corsi/Support/papers-cryptography/gcm-spec.pdf
+// Test vectors from http://luca-giuzzi.unibs.it/corsi/Support/papers-cryptography/gcm-spec.pdf
 
 module Primitive::Symmetric::Cipher::Authenticated::AES_GCM where
 import `Primitive::Symmetric::Cipher::Authenticated::GCM
-import Primitive::Symmetric::Cipher::Block::AES_parameterized
+import Primitive::Symmetric::Cipher::Block::AES_parameterized as AES
 
 
-property testPass0 = gcmEnc `{K=128, IV=96, AAD=0, T=128} {E=encrypt} {key=zero, iv=zero, pt=[], aad=[]} ==
-                              {ct = [], tag = 0x58e2fccefa7e3061367f1d57a4e7455a}
+property GCM_AE_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    where
+        pt = []
+        (ct, tag) = GCM_AE `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt} zero zero pt []
+        dec = GCM_AD `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt} zero zero ct [] tag
+        expected_ct = []
+        expected_tag = 0x58e2fccefa7e3061367f1d57a4e7455a
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False
 
-property testPass1 = gcmEnc `{K=128, IV=96, AAD=0, T=128} {E=encrypt} {key=zero, iv=zero, pt=zero, aad=[]} ==
-                              {ct = 0x0388dace60b6a392f328c2b971b2fe78, tag = 0xab6e47d42cec13bdf53a67b21257bddf}
+property GCM_AE_test_vector_1 =
+    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    where
+        key = zero
+        iv = zero
+        pt = zero
+        aad = []
+        expected_ct = 0x0388dace60b6a392f328c2b971b2fe78
+        expected_tag = 0xab6e47d42cec13bdf53a67b21257bddf : [128]
+        (ct, tag) = GCM_AE `{K=128, IV=96} {E=AES::encrypt} key iv pt aad
+        dec = GCM_AD `{K=128, IV=96} {E=AES::encrypt} key iv ct aad tag
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False
 
-property testPass2 = gcmEnc `{K=128, IV=96, AAD=0, T=128} {E=encrypt} {key=0xfeffe9928665731c6d6a8f9467308308, iv=0xcafebabefacedbaddecaf888,         pt=0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255, aad=[]} ==
-    {ct = 0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985,
-    tag = 0x4d5c2af327cd64a62cf35abd2ba6fab4}
+property GCM_AE_test_vector_2 =
+    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    where
+        key = 0xfeffe9928665731c6d6a8f9467308308 : [128]
+        iv = 0xcafebabefacedbaddecaf888 : [96]
+        pt = 0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255
+        aad = []
+        expected_ct = 0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985
+        expected_tag = 0x4d5c2af327cd64a62cf35abd2ba6fab4 : [128]
+        (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
+        dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False
 
-property testPass3 = gcmEnc `{K=128, IV=96, AAD=160, T=128} {E=encrypt} {key=0xfeffe9928665731c6d6a8f9467308308,                                            iv=0xcafebabefacedbaddecaf888,
-    pt=0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39,
-    aad=0xfeedfacedeadbeeffeedfacedeadbeefabaddad2} ==
-    {ct=0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091,
-    tag=0x5bc94fbc3221a5db94fae95ae7121a47}
+property GCM_AE_test_vector_3 =
+    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    where
+        key = 0xfeffe9928665731c6d6a8f9467308308
+        pt  = 0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39
+        iv  = 0xcafebabefacedbaddecaf888
+        aad = 0xfeedfacedeadbeeffeedfacedeadbeefabaddad2
+        expected_ct  = 0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091
+        expected_tag = 0x5bc94fbc3221a5db94fae95ae7121a47
+        (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
+        dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False
 
 // A test case from aesgcmtest.c
-// Test passes
-property testPass4 = gcmEnc `{K=256, IV=96, AAD=128, T=128} {E=encrypt} {key=0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f,
-    iv=0x99aa3e68ed8173a0eed06684, pt=0xf56e87055bc32d0eeb31b2eacc2bf2a5, aad=0x4d23c3cec334b49bdb370c437fec78de} ==
-   {ct=0xf7264413a84c0e7cd536867eb9f21736, tag=0x67ba0510262ae487d737ee6298f77e0c}
+property GCM_AE_test_vector_4 =
+    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    where
+        key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
+        iv    = 0x99aa3e68ed8173a0eed06684 : [96]
+        pt    = 0xf56e87055bc32d0eeb31b2eacc2bf2a5 : [128]
+        aad   = 0x4d23c3cec334b49bdb370c437fec78de : [128]
+        expected_ct   = 0xf7264413a84c0e7cd536867eb9f21736
+        expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
+        (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
+        dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False
 
-
-
+property GCM_AE_invalid_test_vector =
+    ct == expected_ct /\ tag == expected_tag /\ ~valid_dec
+    where
+        key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
+        iv    = 0x99aa3e68ed8173a0eed06684 : [96]
+        pt    = 0xf56e87055bc32d0eeb31b2eacc2bf2a5 : [128]
+        aad   = 0x4d23c3cec334b49bdb370c437fec78de : [128]
+        expected_ct   = 0xf7264413a84c0e7cd536867eb9f21736
+        expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
+        invalid_tag  = 0x67ba0510262ae487d737ee6298f77888
+        (ct, tag) = GCM_AE {E=AES::encrypt} key iv pt aad
+        dec = GCM_AD {E=AES::encrypt} key iv ct aad invalid_tag
+        valid_dec = case dec of
+            Some actual_pt -> pt == actual_pt
+            None -> False

--- a/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
@@ -10,8 +10,20 @@ module Primitive::Symmetric::Cipher::Authenticated::AES_GCM where
 import `Primitive::Symmetric::Cipher::Authenticated::GCM
 import Primitive::Symmetric::Cipher::Block::AES_parameterized as AES
 
-aesGcmIsSymmetric : [128] -> [96] -> [256] -> [0] -> Bool
+// GCM's symmetry property must hold for AES.
+// The other type parameter sizes are chosen arbitrarily.
+aesGcmIsSymmetric: [128] -> [96] -> [256] -> [0] -> Bool
 property aesGcmIsSymmetric key iv pt aad = gcmIsSymmetric `{T=128} { E=AES::encrypt } key iv pt aad
+
+// GCM's decryption API equivalence must hold for AES.
+// The other type parameter sizes are chosen arbitrarily.
+aesGcmDecryptionApisAreEquivalent: [128] -> [96] -> [256] -> [128] -> Bool
+property aesGcmDecryptionApisAreEquivalent key iv ct tag = decryptionApisAreEquivalent {E=AES::encrypt} key iv ct [] tag
+
+// GCM's encryption API equivalence must hold for AES.
+// The other type parameter sizes are chosen arbitrarily.
+aesGcmEncryptionApisAreEquivalent: [128] -> [96] -> [256] -> [128] -> Bool
+property aesGcmEncryptionApisAreEquivalent key iv pt = decryptionApisAreEquivalent {E=AES::encrypt} key iv pt []
 
 property AES_GCM_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where

--- a/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
@@ -10,8 +10,10 @@ module Primitive::Symmetric::Cipher::Authenticated::AES_GCM where
 import `Primitive::Symmetric::Cipher::Authenticated::GCM
 import Primitive::Symmetric::Cipher::Block::AES_parameterized as AES
 
+aesGcmIsSymmetric : [128] -> [96] -> [256] -> [0] -> Bool
+property aesGcmIsSymmetric key iv pt aad = gcmIsSymmetric `{T=128} { E=AES::encrypt } key iv pt aad
 
-property GCM_AE_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
+property AES_GCM_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         pt = []
         (ct, tag) = GCM_AE `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt} zero zero pt []
@@ -20,7 +22,7 @@ property GCM_AE_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ vali
         expected_tag = 0x58e2fccefa7e3061367f1d57a4e7455a
         valid_dec = dec.valid && (dec.pt == pt)
 
-property GCM_AE_test_vector_1 =
+property AES_GCM_test_vector_1 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key = zero
@@ -33,7 +35,7 @@ property GCM_AE_test_vector_1 =
         dec = GCM_AD `{K=128, IV=96} {E=AES::encrypt} key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property GCM_AE_test_vector_2 =
+property AES_GCM_test_vector_2 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key = 0xfeffe9928665731c6d6a8f9467308308 : [128]
@@ -46,7 +48,7 @@ property GCM_AE_test_vector_2 =
         dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property GCM_AE_test_vector_3 =
+property AES_GCM_test_vector_3 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key = 0xfeffe9928665731c6d6a8f9467308308
@@ -60,7 +62,7 @@ property GCM_AE_test_vector_3 =
         valid_dec = dec.valid && (dec.pt == pt)
 
 // A test case from aesgcmtest.c
-property GCM_AE_test_vector_4 =
+property AES_GCM_test_vector_4 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
@@ -73,7 +75,7 @@ property GCM_AE_test_vector_4 =
         dec = GCM_AD {E=AES::encrypt} key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property GCM_AE_invalid_test_vector =
+property AES_GCM_invalid_test_vector =
     ct == expected_ct /\ tag == expected_tag /\ ~dec.valid
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -53,20 +53,17 @@ GCM_AE k iv p a = (C, T)
   where
     // Set names to match the spec
     CIPHk = E k
-    len_IV = `IV
-    len_A = `AAD
-    len_P = `P
+    type len_A = AAD
+    // Ciphertext length is the same as the input plaintext length
+    type len_C = P
 
     H = CIPHk 0
-    type s = IV %^ 128  // Equivalently: 128 * IV /^ 128 - IV
-    J0 = if len_IV == 96 then coerceSize iv # (0 : [31]) # (1 : [1])
-         else GHASH`{IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (len_IV: [64]))
+    J0 = define_J0 k iv H
     C = GCTR CIPHk (inc`{32} J0) p
-    // Why is this on the value P and not the type / length `P? Ditto for A.
-    type u = P %^ 128 // Equivalently: 128 * P /^ 128 - O
-    type v = AAD %^ 128 // Equivalently: 128 * A /^ 128 - A
-    S = GHASH`{AAD/^ 128 + P /^ 128 + 1}
-            H (a # (0 : [v]) # C # (0 : [u]) # (len_A : [64]) # (len_P : [64]))
+    type u = len_C %^ 128 // Equivalently: 128 * len_C /^ 128 - len_C
+    type v = len_A %^ 128 // Equivalently: 128 * len_A /^ 128 - len_A
+    S = GHASH`{len_A/^ 128 + P /^ 128 + 1}
+            H (a # (0 : [v]) # C # (0 : [u]) # (`len_A : [64]) # (`len_C : [64]))
     T = MSB`{T} (GCTR CIPHk J0 S)
 
 /**
@@ -87,9 +84,7 @@ gcmDec :
   {n} (2^^39 - 256 >= n) =>
   { key : [K], iv  : [IV], aad : [AAD], ct  : [n], tag : [T] } ->
   { valid : Bool, pt : [n] }
-gcmDec input = case (GCM_AD input.key input.iv input.ct input.aad input.tag) of
-    Some pt -> {valid = True, pt = pt}
-    None    -> {valid = False, pt = 0}
+gcmDec input = GCM_AD input.key input.iv input.ct input.aad input.tag
 
 
 /**
@@ -99,37 +94,47 @@ gcmDec input = case (GCM_AD input.key input.iv input.ct input.aad input.tag) of
 
 GCM_AD : { C }
     ( fin C, C <= 2^^39 - 256 )  // This constraint comes from [NISTSP800-38D]
- => [K] -> [IV] -> [C] -> [AAD] -> [T] -> Option [C]
+ => [K] -> [IV] -> [C] -> [AAD] -> [T] -> { valid : Bool, pt : [C] }
 GCM_AD key iv ct aad tag =
   if tag == T'
-  then Some P
-  else None
+  then { valid = True, pt = P }
+  else { valid = False, pt = 0 }
   where
     CIPHk = E key
     len_IV = `IV
-    len_A = `AAD
-    len_C = `C
+    type len_A = AAD
+    type len_C = C
 
     H = CIPHk 0
-    type s = IV %^ 128  // Equivalently: 128 * IV /^ 128 - IV
-    J0 = if len_IV == 96 then coerceSize iv # (0 : [31]) # (1 : [1])
-         else GHASH`{IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (len_IV : [64]))
+    J0 = define_J0 key iv H
     P = GCTR CIPHk (inc`{32} J0) ct
-    type u = C %^ 128 // Equivalently: 128 * C /^ 128 - C
-    type v = AAD %^ 128 // Equivalently: 128 * A /^ 128 - A
-    S = GHASH`{AAD /^ 128 + C /^ 128 + 1}
-            H (aad # (0 : [v]) # ct # (0 : [u]) # (len_A : [64]) # (len_C : [64]))
+    type u = len_C %^ 128 // Equivalently: 128 * len_C /^ 128 - len_C
+    type v = len_A %^ 128 // Equivalently: 128 * len_A /^ 128 - len_A
+    S = GHASH`{len_A /^ 128 + len_C /^ 128 + 1}
+            H (aad # (0 : [v]) # ct # (0 : [u]) # (`len_A : [64]) # (`len_C : [64]))
     T' = MSB`{T} (GCTR CIPHk J0 S)
+
+/**
+ * A helper function used in GCM_AE and GCM_AD. We must define this at the top
+ * level due to its use of Cryptol's numeric constraint guards feature, which
+ * currently only works in top-level definitions.
+ *
+ * This renames the IV type to `len_IV` to better match [NISTSP800-38D].
+ */
+define_J0 : { len_IV } ( len_IV == IV) => [K] -> [len_IV] -> [128] -> [128]
+define_J0 k iv H
+  | len_IV == 96 => iv # (0 : [31]) # (1 : [1])
+  | len_IV != 96 => GHASH`{len_IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (`len_IV: [64]))
+  where
+    // Set names to match the spec
+    type s = len_IV %^ 128  // Equivalently: 128 * len_IV /^ 128 - len_IV
 
 /**
  * Property demonstrating equivalence between `gcmDec` and `GCM_AD`.
  */
- property decryptionApiEquivProperty key iv ct aad tag = success
-    where
-      output = gcmDec { key=key, iv=iv, ct=ct, aad=aad, tag=tag}
-      success = case GCM_AD key iv ct aad tag of
-        Some ae_pt -> output.valid && (ae_pt == output.pt)
-        None       -> ~output.valid
+ property decryptionApiEquivProperty key iv ct aad tag =
+      gcmDec { key=key, iv=iv, ct=ct, aad=aad, tag=tag}
+      == GCM_AD key iv ct aad tag
 
 /**
  * Multiplication Operation on Blocks, [NISTSP800-38D] Section
@@ -206,6 +211,3 @@ GCTR CIPHk ICB X = Y
   where
     Y = X ^ take`{a} (join (map CIPHk CB))
     CB = iterate inc`{32} ICB
-
-coerceSize :  {m,n,a} (fin m, fin n) => [m]a -> [n]a
-coerceSize xs = assert (`m == `n) "coerceSize: size mismatch" [xs@i | i <- [0..<n] ]

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -1,6 +1,7 @@
 /*
 Galois Counter Mode in Cryptol
 Copyright (c) 2017-2018, Galois, Inc.
+Author: Sean Weaver, Marcella Hastings
 
 This implementation follows NIST special publication 800-38D:
 [NISTSP800-38D] Morris Dworkin. Recommendation for Block Cipher Modes

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -2,9 +2,10 @@
 Galois Counter Mode in Cryptol
 Copyright (c) 2017-2018, Galois, Inc.
 
-This implementation follows:
-"The Galois/Counter Mode of Operation (GCM)"
-paper by McGrew and Viega.
+This implementation follows NIST special publickation 800-38D:
+[NISTSP800-38D] Morris Dworkin. Recommendation for Block Cipher Modes
+of Operation: Galois/Counter Mode (GCM) and GMAC. NIST Special
+Publication 800-38D. November 2007.
 */
 
 module Primitive::Symmetric::Cipher::Authenticated::GCM where
@@ -29,82 +30,182 @@ parameter
   /** Block encryption function */
   E : [K] -> [128] -> [128]
 
+/**
+ * GCM encryption function
+ *
+ * Maintaining this API for backwards compatability, but `GCM-AE` is recommended for
+ * more precise spec adherence.
+ */
 gcmEnc :
   {n} (2^^39 - 256 >= n) =>
       { key : [K], iv : [IV], aad : [AAD], pt : [n] } -> { ct : [n], tag : [T] }
 gcmEnc input = { ct = C, tag = T }
-  where (C,T) = enc_dec input.key input.iv input.aad input.pt
+  where (C,T) = GCM_AE input.key input.iv input.pt input.aad
 
+/**
+ * GCM-AE Function, [NISTSP800-38D] Section 7.1, Algorithm 4. This provides
+ * authenticated encryption.
+ */
+
+GCM_AE : { P } (fin P, P <= 2^^39 - 256 ) // This constraint comes from [NISTSP800-38D]
+ => [K] -> [IV] -> [P] -> [AAD] -> ([P], [T])
+GCM_AE k iv p a = (C, T)
+  where
+    // Set names to match the spec
+    CIPHk = E k
+    len_IV = `IV
+    len_A = `AAD
+    len_P = `P
+
+    H = CIPHk 0
+    type s = IV %^ 128  // Equivalently: 128 * IV /^ 128 - IV
+    J0 = if len_IV == 96 then coerceSize iv # (0 : [31]) # (1 : [1])
+         else GHASH`{IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (len_IV: [64]))
+    C = GCTR CIPHk (inc`{32} J0) p
+    // Why is this on the value P and not the type / length `P? Ditto for A.
+    type u = P %^ 128 // Equivalently: 128 * P /^ 128 - O
+    type v = AAD %^ 128 // Equivalently: 128 * A /^ 128 - A
+    S = GHASH`{AAD/^ 128 + P /^ 128 + 1}
+            H (a # (0 : [v]) # C # (0 : [u]) # (len_A : [64]) # (len_P : [64]))
+    T = MSB`{T} (GCTR CIPHk J0 S)
+
+/**
+ * Property demonstrating equivalence between `gcmEnc` and `GCM_AE`.
+ */
+ property encryptionApiEquivProperty key iv pt aad = GCM_AE key iv pt aad == (output.ct, output.tag)
+    where
+      input = { key=key, iv=iv, pt=pt, aad=aad }
+      output = gcmEnc input
+
+/**
+ * GCM decryption function.
+ *
+ * Maintaining this API for backwards compatibility, but `GCM-AD` is recommended
+ * for more precise spec adherence.
+ */
 gcmDec :
   {n} (2^^39 - 256 >= n) =>
   { key : [K], iv  : [IV], aad : [AAD], ct  : [n], tag : [T] } ->
   { valid : Bool, pt : [n] }
-gcmDec input = if input.tag == T then { valid = True, pt = P }
-                                  else { valid = False, pt = 0 }
-  where (P,T) = enc_dec input.key input.iv input.aad input.ct
-
+gcmDec input = case (GCM_AD input.key input.iv input.ct input.aad input.tag) of
+    Some pt -> {valid = True, pt = pt}
+    None    -> {valid = False, pt = 0}
 
 
 /**
-The basic functionality between encryption and decryption.
-In the case of decryption, the plain text is only valid if the tags match.
-*/
-enc_dec :
-  {n} ((2^^39 - 256) >= n) => [K] -> [IV] -> [AAD] -> [n] -> ([n], [T])
-enc_dec K IV A P = (C,T)
+ * GCM-AD Function, [NISTSP800-38D] Section 7.2, Algorithm 5. This provides
+ * authenticated decryption.
+ */
+
+GCM_AD : { C }
+    ( fin C, C <= 2^^39 - 256 )  // This constraint comes from [NISTSP800-38D]
+ => [K] -> [IV] -> [C] -> [AAD] -> [T] -> Option [C]
+GCM_AD key iv ct aad tag =
+  if tag == T'
+  then Some P
+  else None
   where
-  H  = (E K 0)
+    CIPHk = E key
+    len_IV = `IV
+    len_A = `AAD
+    len_C = `C
 
-  Y0 = ifWidth`{96} IV (\IV96 -> IV96 # 1)
-                       (GHASH H [] IV)
+    H = CIPHk 0
+    type s = IV %^ 128  // Equivalently: 128 * IV /^ 128 - IV
+    J0 = if len_IV == 96 then coerceSize iv # (0 : [31]) # (1 : [1])
+         else GHASH`{IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (len_IV : [64]))
+    P = GCTR CIPHk (inc`{32} J0) ct
+    type u = C %^ 128 // Equivalently: 128 * C /^ 128 - C
+    type v = AAD %^ 128 // Equivalently: 128 * A /^ 128 - A
+    S = GHASH`{AAD /^ 128 + C /^ 128 + 1}
+            H (aad # (0 : [v]) # ct # (0 : [u]) # (len_A : [64]) # (len_C : [64]))
+    T' = MSB`{T} (GCTR CIPHk J0 S)
 
-  Ys = [Y0] # [ y+1 | y <- Ys ]
+/**
+ * Property demonstrating equivalence between `gcmDec` and `GCM_AD`.
+ */
+ property decryptionApiEquivProperty key iv ct aad tag = success
+    where
+      output = gcmDec { key=key, iv=iv, ct=ct, aad=aad, tag=tag}
+      success = case GCM_AD key iv ct aad tag of
+        Some ae_pt -> output.valid && (ae_pt == output.pt)
+        None       -> ~output.valid
 
-  Cs = [ p ^ (E K y) | p <- blockify P | y <- drop`{1} Ys ]
-  C  = unblockify Cs
+/**
+ * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+ * 6.3, Algorithm 1. This is optimized to use Cryptol's built-in `pmult` and
+ * `pmod` functions. This operation is described using little-endian
+ * notation, hence the `reverse`s.
+ */
 
-  T = take (GHASH H A C ^ (E K Y0))
+(•) : [128] -> [128] -> [128]
+(•) X Y = reverse (pmod (pmult (reverse X) (reverse Y))
+                        <| 1 + x + x^^2 + x^^7 + x^^128|>)
 
+/**
+ * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+ * 6.3. This matches the spec very closely.
+ */
 
-/** Section 2.3, equation (2) */
-GHASH : {C,A} (64 >= width C, 64 >= width A) => [128] -> [A] -> [C] -> [128]
-GHASH H A C = step (XS ! 0) (wa # wc)
-  where
-  wa = `A : [64]
-  wc = `C : [64]
-
-  XS = [0] # [ step X' B | X' <- XS | B <- blockify A # blockify C ]
-
-  step x b = mult (x ^ b) H
-
-
-
-/** Section 2.5, multiplication in GF(2^^128)
-
-This is simple polynomial multipliation and reduction in Cryptol.
-Somewhat oddly, when thinking of the 128-bits as polynomials,
-the spec treats the most significant bit as the 0 power,
-which is the reason for the `reverse` operations.
-*/
 mult : [128] -> [128] -> [128]
-mult X Y = reverse (pmod (pmult (reverse X) (reverse Y)) irred)
-  where irred = <| 1 + x + x^^2 + x^^7 + x^^128 |>
+mult X Y = last Z
+  where
+    R = 0b11100001 # (0 : [120])
+    Z = [0] # [ if [xi] == 0 then Zi else Zi ^ Vi
+              | Zi <- Z
+              | xi <- X
+              | Vi <- V ]
+    V = [Y] # [ if LSB`{1} Vi == 0 then Vi >> 1 else (Vi >> 1) ^ R
+              | Vi <- V ]
+/**
+ * Property demonstrating equivalence between `mult` and `•`.
+ */
+property multEquivProperty X Y = mult X Y == X • Y
+
+/**
+ * GHASH Function, [NISTSP800-38D] Section 6.4, Algorithm 2.
+ */
+
+GHASH : {m} (fin m) => [128] -> [m * 128] -> [128]
+GHASH H X = last Y
+  where Y = [0] # [ (Yi ^ Xi) • H | Yi <- Y | Xi <- groupBy`{128} X ]
+
+/**
+ * The output of incrementing the right-most s bits of the bit
+ * string X, regarded as the binary representation of an integer, by
+ * 1 modulo 2s, [NISTSP800-38D] Sections 4.2.2 and 6.2. Care was
+ * taken here to ensure `s` could be zero.
+ */
+
+inc : {s, a} (fin s, fin a, a >= s) => [a] -> [a]
+inc X = MSB`{a-s} X # (LSB`{s} X + take (1 : [max s 1]))
 
 
-/** Create blocks as described in the spec, first paragraph of Section 2.3.
-Basically we split into 128-bit chunk and pad the last one with 0. */
-blockify : {n} (fin n) => [n] -> [n /^ 128][128]
-blockify msg = split (msg # 0)
+/**
+ * The bit string consisting of the s right-most bits
+ * of the bit string X, [NISTSP800-38D] Section 4.2.2.
+ */
 
-/** Join back the blocks, dropping any additional padding. */
-unblockify : {n} (fin n) => [n /^ 128][128] -> [n]
-unblockify ms = take (join ms)
+LSB : {s, a} (fin s, fin a, a >= s) => [a] -> [s]
+LSB X = drop X
 
+/**
+ * The bit string consisting of the s left-most bits of
+ * the bit string X, [NISTSP800-38D] Section 4.2.2.
+ */
 
-ifWidth : {w,n,a} (fin n, fin w) => [n] -> ([w] -> a) -> a -> a
-ifWidth thing yep nope = if `w == (`n : [max (width w) (width n)])
-                            then yep (take (thing # (zero : [inf])))
-                            else nope
+MSB : {s, a} (fin s, a >= s) => [a] -> [s]
+MSB X = take X
 
+/**
+ * GCTR Function, [NISTSP800-38D] Section 6.5, Algorithm 3.
+ */
 
+GCTR : {a} (fin a) => ([128] -> [128]) -> [128] -> [a] -> [a]
+GCTR CIPHk ICB X = Y
+  where
+    Y = X ^ take`{a} (join (map CIPHk CB))
+    CB = iterate inc`{32} ICB
 
+coerceSize :  {m,n,a} (fin m, fin n) => [m]a -> [n]a
+coerceSize xs = assert (`m == `n) "coerceSize: size mismatch" [xs@i | i <- [0..<n] ]

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -2,7 +2,7 @@
 Galois Counter Mode in Cryptol
 Copyright (c) 2017-2018, Galois, Inc.
 
-This implementation follows NIST special publickation 800-38D:
+This implementation follows NIST special publication 800-38D:
 [NISTSP800-38D] Morris Dworkin. Recommendation for Block Cipher Modes
 of Operation: Galois/Counter Mode (GCM) and GMAC. NIST Special
 Publication 800-38D. November 2007.
@@ -67,14 +67,6 @@ GCM_AE k iv p a = (C, T)
     T = MSB`{T} (GCTR CIPHk J0 S)
 
 /**
- * Property demonstrating equivalence between `gcmEnc` and `GCM_AE`.
- */
- property encryptionApiEquivProperty key iv pt aad = GCM_AE key iv pt aad == (output.ct, output.tag)
-    where
-      input = { key=key, iv=iv, pt=pt, aad=aad }
-      output = gcmEnc input
-
-/**
  * GCM decryption function.
  *
  * Maintaining this API for backwards compatibility, but `GCM-AD` is recommended
@@ -115,99 +107,127 @@ GCM_AD key iv ct aad tag =
     T' = MSB`{T} (GCTR CIPHk J0 S)
 
 /**
- * A helper function used in GCM_AE and GCM_AD. We must define this at the top
- * level due to its use of Cryptol's numeric constraint guards feature, which
- * currently only works in top-level definitions.
- *
- * This renames the IV type to `len_IV` to better match [NISTSP800-38D].
- */
-define_J0 : { len_IV } ( len_IV == IV) => [K] -> [len_IV] -> [128] -> [128]
-define_J0 k iv H
-  | len_IV == 96 => iv # (0 : [31]) # (1 : [1])
-  | len_IV != 96 => GHASH`{len_IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (`len_IV: [64]))
-  where
-    // Set names to match the spec
-    type s = len_IV %^ 128  // Equivalently: 128 * len_IV /^ 128 - len_IV
+* Property demonstrating equivalence between `mult` and `•`.
+*/
+
+property dotAndMultAreEquivalent X Y = mult X Y == X • Y
 
 /**
- * Property demonstrating equivalence between `gcmDec` and `GCM_AD`.
- */
- property decryptionApiEquivProperty key iv ct aad tag =
+* Property demonstrating equivalence between `gcmDec` and `GCM_AD`.
+*/
+decryptionApisAreEquivalent : {P} ( fin P, P <= 2^^39 - 256 )
+  => [K] -> [IV] -> [P] -> [AAD] -> [T] -> Bool
+property decryptionApisAreEquivalent key iv ct aad tag =
       gcmDec { key=key, iv=iv, ct=ct, aad=aad, tag=tag}
       == GCM_AD key iv ct aad tag
 
 /**
- * Multiplication Operation on Blocks, [NISTSP800-38D] Section
- * 6.3, Algorithm 1. This is optimized to use Cryptol's built-in `pmult` and
- * `pmod` functions. This operation is described using little-endian
- * notation, hence the `reverse`s.
+ * Property demonstrating equivalence between `gcmEnc` and `GCM_AE`.
  */
-
-(•) : [128] -> [128] -> [128]
-(•) X Y = reverse (pmod (pmult (reverse X) (reverse Y))
-                        <| 1 + x + x^^2 + x^^7 + x^^128|>)
+encryptionApisAreEquivalent : {P} ( fin P, P <= 2^^39 - 256 )
+  => [K] -> [IV] -> [P] -> [AAD] -> Bool
+property encryptionApisAreEquivalent key iv pt aad = gcm_ae_output == (gcmEnc_output.ct, gcmEnc_output.tag)
+    where
+      input = { key=key, iv=iv, pt=pt, aad=aad }
+      gcmEnc_output = gcmEnc input
+      gcm_ae_output = GCM_AE key iv pt aad
 
 /**
- * Multiplication Operation on Blocks, [NISTSP800-38D] Section
- * 6.3. This matches the spec very closely.
+ * Property demonstrating that decryption is the inverse of encryption.
+ *
+ * This should be instantiated for each block cipher `E` that uses GCM mode.
  */
+gcmIsSymmetric : {P} ( fin P, P < 2^^39 - 256 )
+  => [K] -> [IV] -> [P] -> [AAD] -> Bool
+property gcmIsSymmetric key iv pt aad = dec.valid && (dec.pt == pt)
+    where
+        (ct, tag) = GCM_AE key iv pt aad
+        dec = GCM_AD key iv ct aad tag
 
-mult : [128] -> [128] -> [128]
-mult X Y = last Z
-  where
-    R = 0b11100001 # (0 : [120])
-    Z = [0] # [ if [xi] == 0 then Zi else Zi ^ Vi
-              | Zi <- Z
-              | xi <- X
-              | Vi <- V ]
-    V = [Y] # [ if LSB`{1} Vi == 0 then Vi >> 1 else (Vi >> 1) ^ R
-              | Vi <- V ]
-/**
- * Property demonstrating equivalence between `mult` and `•`.
- */
-property multEquivProperty X Y = mult X Y == X • Y
+private
+  /**
+  * A helper function used in GCM_AE and GCM_AD. We must define this at the top
+  * level due to its use of Cryptol's numeric constraint guards feature, which
+  * currently only works in top-level definitions.
+  *
+  * This renames the IV type to `len_IV` to better match [NISTSP800-38D].
+  */
+  define_J0 : { len_IV } ( len_IV == IV) => [K] -> [len_IV] -> [128] -> [128]
+  define_J0 k iv H
+    | len_IV == 96 => iv # (0 : [31]) # (1 : [1])
+    | len_IV != 96 => GHASH`{len_IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (`len_IV: [64]))
+    where
+      // Set names to match the spec
+      type s = len_IV %^ 128  // Equivalently: 128 * len_IV /^ 128 - len_IV
 
-/**
- * GHASH Function, [NISTSP800-38D] Section 6.4, Algorithm 2.
- */
+  /**
+  * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+  * 6.3, Algorithm 1. This is optimized to use Cryptol's built-in `pmult` and
+  * `pmod` functions. This operation is described using little-endian
+  * notation, hence the `reverse`s.
+  */
 
-GHASH : {m} (fin m) => [128] -> [m * 128] -> [128]
-GHASH H X = last Y
-  where Y = [0] # [ (Yi ^ Xi) • H | Yi <- Y | Xi <- groupBy`{128} X ]
+  (•) : [128] -> [128] -> [128]
+  (•) X Y = reverse (pmod (pmult (reverse X) (reverse Y))
+                          <| 1 + x + x^^2 + x^^7 + x^^128|>)
 
-/**
- * The output of incrementing the right-most s bits of the bit
- * string X, regarded as the binary representation of an integer, by
- * 1 modulo 2s, [NISTSP800-38D] Sections 4.2.2 and 6.2. Care was
- * taken here to ensure `s` could be zero.
- */
+  /**
+  * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+  * 6.3. This matches the spec very closely.
+  */
 
-inc : {s, a} (fin s, fin a, a >= s) => [a] -> [a]
-inc X = MSB`{a-s} X # (LSB`{s} X + take (1 : [max s 1]))
+  mult : [128] -> [128] -> [128]
+  mult X Y = last Z
+    where
+      R = 0b11100001 # (0 : [120])
+      Z = [0] # [ if [xi] == 0 then Zi else Zi ^ Vi
+                | Zi <- Z
+                | xi <- X
+                | Vi <- V ]
+      V = [Y] # [ if LSB`{1} Vi == 0 then Vi >> 1 else (Vi >> 1) ^ R
+                | Vi <- V ]
+
+  /**
+  * GHASH Function, [NISTSP800-38D] Section 6.4, Algorithm 2.
+  */
+
+  GHASH : {m} (fin m) => [128] -> [m * 128] -> [128]
+  GHASH H X = last Y
+    where Y = [0] # [ (Yi ^ Xi) • H | Yi <- Y | Xi <- groupBy`{128} X ]
+
+  /**
+  * The output of incrementing the right-most s bits of the bit
+  * string X, regarded as the binary representation of an integer, by
+  * 1 modulo 2s, [NISTSP800-38D] Sections 4.2.2 and 6.2. Care was
+  * taken here to ensure `s` could be zero.
+  */
+
+  inc : {s, a} (fin s, fin a, a >= s) => [a] -> [a]
+  inc X = MSB`{a-s} X # (LSB`{s} X + take (1 : [max s 1]))
 
 
-/**
- * The bit string consisting of the s right-most bits
- * of the bit string X, [NISTSP800-38D] Section 4.2.2.
- */
+  /**
+  * The bit string consisting of the s right-most bits
+  * of the bit string X, [NISTSP800-38D] Section 4.2.2.
+  */
 
-LSB : {s, a} (fin s, fin a, a >= s) => [a] -> [s]
-LSB X = drop X
+  LSB : {s, a} (fin s, fin a, a >= s) => [a] -> [s]
+  LSB X = drop X
 
-/**
- * The bit string consisting of the s left-most bits of
- * the bit string X, [NISTSP800-38D] Section 4.2.2.
- */
+  /**
+  * The bit string consisting of the s left-most bits of
+  * the bit string X, [NISTSP800-38D] Section 4.2.2.
+  */
 
-MSB : {s, a} (fin s, a >= s) => [a] -> [s]
-MSB X = take X
+  MSB : {s, a} (fin s, a >= s) => [a] -> [s]
+  MSB X = take X
 
-/**
- * GCTR Function, [NISTSP800-38D] Section 6.5, Algorithm 3.
- */
+  /**
+  * GCTR Function, [NISTSP800-38D] Section 6.5, Algorithm 3.
+  */
 
-GCTR : {a} (fin a) => ([128] -> [128]) -> [128] -> [a] -> [a]
-GCTR CIPHk ICB X = Y
-  where
-    Y = X ^ take`{a} (join (map CIPHk CB))
-    CB = iterate inc`{32} ICB
+  GCTR : {a} (fin a) => ([128] -> [128]) -> [128] -> [a] -> [a]
+  GCTR CIPHk ICB X = Y
+    where
+      Y = X ^ take`{a} (join (map CIPHk CB))
+      CB = iterate inc`{32} ICB

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -1,10 +1,26 @@
 :l AES_GCM.cry
 
-:prove GCM_AE_test_vector_0
-:prove GCM_AE_test_vector_1
-:prove GCM_AE_test_vector_2
-:prove GCM_AE_test_vector_3
-:prove GCM_AE_test_vector_4
-:prove GCM_AE_invalid_test_vector
+:prove AES_GCM_test_vector_0
+:prove AES_GCM_test_vector_1
+:prove AES_GCM_test_vector_2
+:prove AES_GCM_test_vector_3
+:prove AES_GCM_test_vector_4
+:prove AES_GCM_invalid_test_vector
 
-// TODO: add equivalence properties (mult, enc, dec)
+// The following checks do not really provide any significant formal
+// verification because they check so little of the sample space.
+
+// These properties can be checked manually; one of the APIs calls the other.
+// They take more than an hour to prove.
+:check decryptionApisAreEquivalent `{K=128, IV=96, AAD=0, T=128, P=256} {E=AES::encrypt}
+:check encryptionApisAreEquivalent `{K=128, IV=96, AAD=0, T=128, P=256} {E=AES::encrypt}
+
+// This property is independent of the type parameters but we have to specify
+// them anyway.
+// It takes more than 25 minutes to prove.
+:check dotAndMultAreEquivalent `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt}
+
+// Make sure that decryption is the inverse of encryption
+// This property takes more than 20 minutes to prove
+// It's also spot-checked in the test vectors
+:check aesGcmIsSymmetric

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -1,0 +1,10 @@
+:l AES_GCM.cry
+
+:prove GCM_AE_test_vector_0
+:prove GCM_AE_test_vector_1
+:prove GCM_AE_test_vector_2
+:prove GCM_AE_test_vector_3
+:prove GCM_AE_test_vector_4
+:prove GCM_AE_invalid_test_vector
+
+// TODO: add equivalence properties (mult, enc, dec)

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -9,18 +9,20 @@
 
 // The following checks do not really provide any significant formal
 // verification because they check so little of the sample space.
+// They each take a long time to `:prove` and would likely require
+// manual modification to prove in a reasonable amount of time.
 
 // These properties can be checked manually; one of the APIs calls the other.
-// They take more than an hour to prove.
-:check decryptionApisAreEquivalent `{K=128, IV=96, AAD=0, T=128, P=256} {E=AES::encrypt}
-:check encryptionApisAreEquivalent `{K=128, IV=96, AAD=0, T=128, P=256} {E=AES::encrypt}
+// They take more than an hour to `:prove`.
+:check aesGcmDecryptionApisAreEquivalent
+:check aesGcmEncryptionApisAreEquivalent
 
 // This property is independent of the type parameters but we have to specify
 // them anyway.
-// It takes more than 25 minutes to prove.
+// It takes more than 25 minutes to `:prove`.
 :check dotAndMultAreEquivalent `{K=128, IV=96, AAD=0, T=128} {E=AES::encrypt}
 
 // Make sure that decryption is the inverse of encryption
-// This property takes more than 20 minutes to prove
+// This property takes more than 20 minutes to `:prove`.
 // It's also spot-checked in the test vectors
 :check aesGcmIsSymmetric


### PR DESCRIPTION
Closes #46. Closes #74. Closes #47.

Here's an update to the AES-GCM spec that fixes the decryption bug (decryption was just implemented incorrectly, and it was never tested / proven to work anyway). 
The existing version of AES is based on what I think is a submission document for the GCM algorithm. The format, algorithm names, and parameter names were changed at some point, and the official NIST standard uses some slightly different notation. I kept the old APIs in because it seems like they're being used, but changed the references and everything else to adhere to the NIST spec.

Conveniently, there were several correct implementations floating around:
- In the original issue, folks proposed and implemented (#47) adding a flag to this version to make decryption correct
- Also in the original issue, [someone provided a different implementation](https://github.com/GaloisInc/cryptol-specs/issues/46#issuecomment-1085018600) that more closely adheres to the AES-GCM NIST spec. This forms the basis of most of the changes in this PR.

This PR:
- fixes the spec to be correct
- update the properties to validate decryption (to some degree, see following questions)
- adds a NIST-adherent API and states an equivalence property to the existing API
- adds a basic encryption / decryption is symmetric property
- adds a batch file to prove the test vectors and check the new and existing properties. I have not actually proven any of the properties that are currently `:check`ed in the file; I added docs with a note of how long I waited.

This is now [ready for review!](https://github.com/GaloisInc/cryptol-specs/pull/75#pullrequestreview-2123614190)
---
These questions have been answered:
- The version from `weaversa` had a requirement that P, IV, and A are all finite. Is that redundant if we have size upper bounds on each of them? Does it still allow negative infinity? Is the fact that it's used as a length enforce that it's non-negative?
- Style question: Taking / returning a named record vs a set of parameters. Why would we do one vs the other?
- How can we make two type variables and constraint them to be the same, so that things look more like the human spec? (P = len_C)
- Guidelines on when to use module-level parameters vs function-level?
- How do I go about doing something useful with the equivalence properties in gcm.cry? Should I prove these in the batch file for some typical parameter sets? Is there a way to say for all?

I want to look into the following items:
- I think the set of acceptable tag lengths is informed by the other parameters, or there might be acceptable sets in general and it should disallow other kinds (beyond just the individual length requirements). See if this is true and if we can enforce it
- GHASH. Check if 128 is correct fixed size for hash or if that should be a parameter as well
- I think there are additional properties that we could demo here as well, like wrong tag => invalid decryption (statistically at least)