### PR TITLE
Improve code quality on GCM mode

### DIFF
--- a/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/AES_GCM.cry
@@ -22,16 +22,6 @@ AES256_GCM_decrypt = GCM_AD `{K=256} {E=AES256::encrypt}
 aesGcmIsSymmetric: [128] -> [96] -> [256] -> [0] -> Bool
 property aesGcmIsSymmetric key iv pt aad = gcmIsSymmetric `{T=128} { E=AES128::encrypt } key iv pt aad
 
-// GCM's decryption API equivalence must hold for AES.
-// The other type parameter sizes are chosen arbitrarily.
-aesGcmDecryptionApisAreEquivalent: [128] -> [96] -> [256] -> [128] -> Bool
-property aesGcmDecryptionApisAreEquivalent key iv ct tag = decryptionApisAreEquivalent {E=AES128::encrypt} key iv ct [] tag
-
-// GCM's encryption API equivalence must hold for AES.
-// The other type parameter sizes are chosen arbitrarily.
-aesGcmEncryptionApisAreEquivalent: [128] -> [96] -> [256] -> [128] -> Bool
-property aesGcmEncryptionApisAreEquivalent key iv pt = decryptionApisAreEquivalent {E=AES128::encrypt} key iv pt []
-
 property AES_GCM_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         pt = []

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -15,9 +15,15 @@ This implementation deviates from the original spec in the following ways:
 
 ⚠️ Warning ⚠️: There are several properties of GCM mode that Cryptol cannot
 enforce! These include:
-- GCM mode will fail catastrophically if a (key, IV) pair is ever reused.
+- GCM mode will fail catastrophically if a (key, IV) pair is ever reused
+  to encrypt different pieces of data.
   Implementors must manually verify that keys and IVs are chosen in such
-  a way that they will not be reused.
+  a way that they will not be reused. See [NIST-SP-800-38D] Section 8.
+- The total number of invocations of `GCM_AE` with a given key must not
+  exceed 2^{32}. This is to prevent the catastrophic failure in the previous
+  point. Cryptol cannot evaluate the "global" use of the encryption function.
+- The intermediate values used in the execution of GCM functions must be
+  secret, and not reused or recomputed for any other purpose.
 - The original spec requires an implementation with `GCM_AE` and `GCM_AD`
   must support the same ciphertext, associated data, and IV lengths for
   both algorithms.
@@ -210,3 +216,14 @@ private
     where
       Y = X ^ take`{a} (join (map CIPHk CB))
       CB = iterate inc`{32} ICB
+
+  /**
+   * GCTR should return an empty output when given an empty input.
+   * This property is described in [NIST-SP-800-38D], Algorithm 3.
+   * It can be `:prove`n.
+   */
+  emptyInputProducesEmptyOutputGCTR : [C::KeySize] -> [128] -> Bool
+  property emptyInputProducesEmptyOutputGCTR key icb =
+   zero == (GCTR CIPHk icb (zero : [0]))
+    where
+      CIPHk = C::encrypt key

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -7,45 +7,78 @@ This implementation follows NIST special publication 800-38D:
 [NIST-SP-800-38D] Morris Dworkin. Recommendation for Block Cipher Modes
 of Operation: Galois/Counter Mode (GCM) and GMAC. NIST Special
 Publication 800-38D. November 2007.
+
+This implementation deviates from the original spec in the following ways:
+- The original spec allows tag lengths 96, 104, 112, 120, and 128 in all
+  settings, and allows length 64 or 32 in certain applications. This
+  implementation does not allow short tags (32 or 64) at all.
+
+⚠️ Warning ⚠️: There are several properties of GCM mode that Cryptol cannot
+enforce! These include:
+- GCM mode will fail catastrophically if a (key, IV) pair is ever reused.
+  Implementors must manually verify that keys and IVs are chosen in such
+  a way that they will not be reused.
+- The original spec requires an implementation with `GCM_AE` and `GCM_AD`
+  must support the same ciphertext, associated data, and IV lengths for
+  both algorithms.
 */
 
 module Primitive::Symmetric::Cipher::Authenticated::GCM where
 import interface Primitive::Symmetric::Cipher::Block::CipherInterface as C
-
-// GCM mode is only defined for ciphers that operate over 128-bit blocks.
+/**
+ * GCM mode is only defined for ciphers that operate over 128-bit blocks.
+ * [NIST-SP-800-38D] Section 5.1
+ */
 interface constraint (C::BlockSize == 128)
+/**
+ * GCM mode is only defined for ciphers with a key size of at least 128 bits.
+ * [NIST-SP-800-38D] Section 5.1
+ *
+ * ⚠️ Warning ⚠️: GCM mode has other requirements on the key that cannot be
+ * enforced by Cryptol (for example, that it is generated uniformly at random).
+ * See Section 8.1 of [NIST-SP-800-38D].
+ */
+ interface constraint (128 <= C::KeySize)
 
-type constraint ValidIV IV = (64 >= width IV, IV >= 1)
-type constraint ValidAAD AAD = (64 >= width AAD)
-type constraint ValidTag T = (128 >= T, T >= 64)
+/**
+ * The IV has bit length `1 ≤ IV ≤ 2^64 - 1` and is a multiple of 8.
+ * [NIST-SP-800-38D] Section 5.2.1.1
+ */
+type constraint ValidIV IV = (width IV <= 64, IV >= 1, IV % 8 == 0)
+/**
+ * The associated data has bit length `AAD ≤ 2^64 - 1` and is a multiple of 8.
+ * [NIST-SP-800-38D] Section 5.2.1.1
+ */
+type constraint ValidAAD AAD = (width AAD <= 64, AAD % 8 == 0)
+/**
+ * The tag T can be of length 96, 104, 112, 120, or 128.
+ * [NIST-SP-800-38D] Section 5.2.1.2
+ */
+type constraint ValidTag T = (fin T, T % 8 == 0, T / 8 >= 12, T / 8 <= 16)
 /**
  * The plaintext (for encryption) and ciphertext (for decryption) must not
- * be too large.
- * This constraint comes from [NIST-SP-800-38D].
+ * be too large and is a multiple of 8.
+ * [NIST-SP-800-38D] Section 5.2.1.1 (for plaintexts) and Section 5.2.2
+ * (for ciphertexts).
  */
-type constraint ValidText P = (fin P, P <= 2^^39 - 256 )
+type constraint ValidText P = (fin P, P <= 2^^39 - 256, P % 8 == 0)
 
 /**
  * GCM-AE Function, [NIST-SP-800-38D] Section 7.1, Algorithm 4. This provides
  * authenticated encryption.
  */
-
-GCM_AE : { P, IV, AAD, T } (ValidText P, ValidIV IV, ValidAAD AAD, ValidTag T)
- => [C::KeySize] -> [IV] -> [P] -> [AAD] -> ([P], [T])
+GCM_AE : { len_C, len_IV, len_A, T } (ValidText len_C, ValidIV len_IV, ValidAAD len_A, ValidTag T)
+ => [C::KeySize] -> [len_IV] -> [len_C] -> [len_A] -> ([len_C], [T])
 GCM_AE k iv p a = (C, T)
   where
-    // Set names to match the spec
     CIPHk = C::encrypt k
-    type len_A = AAD
-    // Ciphertext length is the same as the input plaintext length
-    type len_C = P
 
     H = CIPHk 0
     J0 = define_J0 k iv H
     C = GCTR CIPHk (inc`{32} J0) p
     type u = len_C %^ 128 // Equivalently: 128 * len_C /^ 128 - len_C
     type v = len_A %^ 128 // Equivalently: 128 * len_A /^ 128 - len_A
-    S = GHASH`{len_A/^ 128 + P /^ 128 + 1}
+    S = GHASH`{len_A/^ 128 + len_C /^ 128 + 1}
             H (a # (0 : [v]) # C # (0 : [u]) # (`len_A : [64]) # (`len_C : [64]))
     T = MSB`{T} (GCTR CIPHk J0 S)
 
@@ -54,17 +87,14 @@ GCM_AE k iv p a = (C, T)
  * authenticated decryption.
  */
 
-GCM_AD : { C, IV, AAD, T } (ValidText C, ValidIV IV, ValidAAD AAD, ValidTag T)
- => [C::KeySize] -> [IV] -> [C] -> [AAD] -> [T] -> { valid : Bool, pt : [C] }
+GCM_AD : { len_C, len_IV, len_A, T } (ValidText len_C, ValidIV len_IV, ValidAAD len_A, ValidTag T)
+ => [C::KeySize] -> [len_IV] -> [len_C] -> [len_A] -> [T] -> { valid : Bool, pt : [len_C] }
 GCM_AD key iv ct aad tag =
   if tag == T'
   then { valid = True, pt = P }
   else { valid = False, pt = 0 }
   where
     CIPHk = C::encrypt key
-    len_IV = `IV
-    type len_A = AAD
-    type len_C = C
 
     H = CIPHk 0
     J0 = define_J0 key iv H
@@ -98,14 +128,13 @@ private
   * level due to its use of Cryptol's numeric constraint guards feature, which
   * currently only works in top-level definitions.
   *
-  * This renames the IV type to `len_IV` to better match [NIST-SP-800-38D].
+  * See [NIST-SP-800-38D] Algorithm 4, Step 2 and Algorithm 5, Step 3.
   */
   define_J0 : { len_IV } ( ValidIV len_IV ) => [C::KeySize] -> [len_IV] -> [128] -> [128]
   define_J0 k iv H
     | len_IV == 96 => iv # (0 : [31]) # (1 : [1])
     | len_IV != 96 => GHASH`{len_IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (`len_IV: [64]))
     where
-      // Set names to match the spec
       type s = len_IV %^ 128  // Equivalently: 128 * len_IV /^ 128 - len_IV
 
   /**

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -31,17 +31,6 @@ parameter
   /** Block encryption function */
   E : [K] -> [128] -> [128]
 
-/**
- * GCM encryption function
- *
- * Maintaining this API for backwards compatability, but `GCM-AE` is recommended for
- * more precise spec adherence.
- */
-gcmEnc :
-  {n} (2^^39 - 256 >= n) =>
-      { key : [K], iv : [IV], aad : [AAD], pt : [n] } -> { ct : [n], tag : [T] }
-gcmEnc input = { ct = C, tag = T }
-  where (C,T) = GCM_AE input.key input.iv input.pt input.aad
 
 /**
  * GCM-AE Function, [NISTSP800-38D] Section 7.1, Algorithm 4. This provides
@@ -66,19 +55,6 @@ GCM_AE k iv p a = (C, T)
     S = GHASH`{len_A/^ 128 + P /^ 128 + 1}
             H (a # (0 : [v]) # C # (0 : [u]) # (`len_A : [64]) # (`len_C : [64]))
     T = MSB`{T} (GCTR CIPHk J0 S)
-
-/**
- * GCM decryption function.
- *
- * Maintaining this API for backwards compatibility, but `GCM-AD` is recommended
- * for more precise spec adherence.
- */
-gcmDec :
-  {n} (2^^39 - 256 >= n) =>
-  { key : [K], iv  : [IV], aad : [AAD], ct  : [n], tag : [T] } ->
-  { valid : Bool, pt : [n] }
-gcmDec input = GCM_AD input.key input.iv input.ct input.aad input.tag
-
 
 /**
  * GCM-AD Function, [NISTSP800-38D] Section 7.2, Algorithm 5. This provides
@@ -110,28 +86,7 @@ GCM_AD key iv ct aad tag =
 /**
 * Property demonstrating equivalence between `mult` and `•`.
 */
-
 property dotAndMultAreEquivalent X Y = mult X Y == X • Y
-
-/**
-* Property demonstrating equivalence between `gcmDec` and `GCM_AD`.
-*/
-decryptionApisAreEquivalent : {P} ( fin P, P <= 2^^39 - 256 )
-  => [K] -> [IV] -> [P] -> [AAD] -> [T] -> Bool
-property decryptionApisAreEquivalent key iv ct aad tag =
-      gcmDec { key=key, iv=iv, ct=ct, aad=aad, tag=tag}
-      == GCM_AD key iv ct aad tag
-
-/**
- * Property demonstrating equivalence between `gcmEnc` and `GCM_AE`.
- */
-encryptionApisAreEquivalent : {P} ( fin P, P <= 2^^39 - 256 )
-  => [K] -> [IV] -> [P] -> [AAD] -> Bool
-property encryptionApisAreEquivalent key iv pt aad = gcm_ae_output == (gcmEnc_output.ct, gcmEnc_output.tag)
-    where
-      input = { key=key, iv=iv, pt=pt, aad=aad }
-      gcmEnc_output = gcmEnc input
-      gcm_ae_output = GCM_AE key iv pt aad
 
 /**
  * Property demonstrating that decryption is the inverse of encryption.

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -1,7 +1,9 @@
 /*
 Galois Counter Mode in Cryptol
-Copyright (c) 2017-2018, Galois, Inc.
-Author: Sean Weaver, Marcella Hastings
+
+@copyright Galois, Inc.
+@author Sean Weaver
+@author Marcella Hastings <marcella@galois.com>
 
 This implementation follows NIST special publication 800-38D:
 [NIST-SP-800-38D] Morris Dworkin. Recommendation for Block Cipher Modes

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -86,13 +86,12 @@ GCM_AE k iv p a = (C, T)
  * GCM-AD Function, [NIST-SP-800-38D] Section 7.2, Algorithm 5. This provides
  * authenticated decryption.
  */
-
 GCM_AD : { len_C, len_IV, len_A, T } (ValidText len_C, ValidIV len_IV, ValidAAD len_A, ValidTag T)
- => [C::KeySize] -> [len_IV] -> [len_C] -> [len_A] -> [T] -> { valid : Bool, pt : [len_C] }
+ => [C::KeySize] -> [len_IV] -> [len_C] -> [len_A] -> [T] -> Option [len_C]
 GCM_AD key iv ct aad tag =
   if tag == T'
-  then { valid = True, pt = P }
-  else { valid = False, pt = 0 }
+  then Some P
+  else None
   where
     CIPHk = C::encrypt key
 
@@ -117,10 +116,13 @@ property dotAndMultAreEquivalent X Y = mult X Y == X • Y
  */
 gcmIsSymmetric : { P, IV, AAD } ( ValidText P, ValidIV IV, ValidAAD AAD )
   => [C::KeySize] -> [IV] -> [P] -> [AAD] -> Bool
-property gcmIsSymmetric key iv pt aad = dec.valid && (dec.pt == pt)
+property gcmIsSymmetric key iv pt aad = is_symmetric
     where
         (ct, tag : [96]) = GCM_AE key iv pt aad
         dec = GCM_AD key iv ct aad tag
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
 
 private
   /**

--- a/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/GCM.cry
@@ -4,45 +4,38 @@ Copyright (c) 2017-2018, Galois, Inc.
 Author: Sean Weaver, Marcella Hastings
 
 This implementation follows NIST special publication 800-38D:
-[NISTSP800-38D] Morris Dworkin. Recommendation for Block Cipher Modes
+[NIST-SP-800-38D] Morris Dworkin. Recommendation for Block Cipher Modes
 of Operation: Galois/Counter Mode (GCM) and GMAC. NIST Special
 Publication 800-38D. November 2007.
 */
 
 module Primitive::Symmetric::Cipher::Authenticated::GCM where
+import interface Primitive::Symmetric::Cipher::Block::CipherInterface as C
 
-parameter
-  /** Key size */
-  type K : #
-  type constraint (fin K)
+// GCM mode is only defined for ciphers that operate over 128-bit blocks.
+interface constraint (C::BlockSize == 128)
 
-  /** Size of initialization vector */
-  type IV : #
-  type constraint (64 >= width IV, IV >= 1)
-
-  /** Size of additional authenticated data */
-  type AAD  : #
-  type constraint (64 >= width AAD)
-
-  /** Size of authentication tag */
-  type T : #
-  type constraint (128 >= T, T >= 64)
-
-  /** Block encryption function */
-  E : [K] -> [128] -> [128]
-
+type constraint ValidIV IV = (64 >= width IV, IV >= 1)
+type constraint ValidAAD AAD = (64 >= width AAD)
+type constraint ValidTag T = (128 >= T, T >= 64)
+/**
+ * The plaintext (for encryption) and ciphertext (for decryption) must not
+ * be too large.
+ * This constraint comes from [NIST-SP-800-38D].
+ */
+type constraint ValidText P = (fin P, P <= 2^^39 - 256 )
 
 /**
- * GCM-AE Function, [NISTSP800-38D] Section 7.1, Algorithm 4. This provides
+ * GCM-AE Function, [NIST-SP-800-38D] Section 7.1, Algorithm 4. This provides
  * authenticated encryption.
  */
 
-GCM_AE : { P } (fin P, P <= 2^^39 - 256 ) // This constraint comes from [NISTSP800-38D]
- => [K] -> [IV] -> [P] -> [AAD] -> ([P], [T])
+GCM_AE : { P, IV, AAD, T } (ValidText P, ValidIV IV, ValidAAD AAD, ValidTag T)
+ => [C::KeySize] -> [IV] -> [P] -> [AAD] -> ([P], [T])
 GCM_AE k iv p a = (C, T)
   where
     // Set names to match the spec
-    CIPHk = E k
+    CIPHk = C::encrypt k
     type len_A = AAD
     // Ciphertext length is the same as the input plaintext length
     type len_C = P
@@ -57,19 +50,18 @@ GCM_AE k iv p a = (C, T)
     T = MSB`{T} (GCTR CIPHk J0 S)
 
 /**
- * GCM-AD Function, [NISTSP800-38D] Section 7.2, Algorithm 5. This provides
+ * GCM-AD Function, [NIST-SP-800-38D] Section 7.2, Algorithm 5. This provides
  * authenticated decryption.
  */
 
-GCM_AD : { C }
-    ( fin C, C <= 2^^39 - 256 )  // This constraint comes from [NISTSP800-38D]
- => [K] -> [IV] -> [C] -> [AAD] -> [T] -> { valid : Bool, pt : [C] }
+GCM_AD : { C, IV, AAD, T } (ValidText C, ValidIV IV, ValidAAD AAD, ValidTag T)
+ => [C::KeySize] -> [IV] -> [C] -> [AAD] -> [T] -> { valid : Bool, pt : [C] }
 GCM_AD key iv ct aad tag =
   if tag == T'
   then { valid = True, pt = P }
   else { valid = False, pt = 0 }
   where
-    CIPHk = E key
+    CIPHk = C::encrypt key
     len_IV = `IV
     type len_A = AAD
     type len_C = C
@@ -91,13 +83,13 @@ property dotAndMultAreEquivalent X Y = mult X Y == X • Y
 /**
  * Property demonstrating that decryption is the inverse of encryption.
  *
- * This should be instantiated for each block cipher `E` that uses GCM mode.
+ * This should be instantiated for each block cipher `C::encrypt` that uses GCM mode.
  */
-gcmIsSymmetric : {P} ( fin P, P < 2^^39 - 256 )
-  => [K] -> [IV] -> [P] -> [AAD] -> Bool
+gcmIsSymmetric : { P, IV, AAD } ( ValidText P, ValidIV IV, ValidAAD AAD )
+  => [C::KeySize] -> [IV] -> [P] -> [AAD] -> Bool
 property gcmIsSymmetric key iv pt aad = dec.valid && (dec.pt == pt)
     where
-        (ct, tag) = GCM_AE key iv pt aad
+        (ct, tag : [96]) = GCM_AE key iv pt aad
         dec = GCM_AD key iv ct aad tag
 
 private
@@ -106,9 +98,9 @@ private
   * level due to its use of Cryptol's numeric constraint guards feature, which
   * currently only works in top-level definitions.
   *
-  * This renames the IV type to `len_IV` to better match [NISTSP800-38D].
+  * This renames the IV type to `len_IV` to better match [NIST-SP-800-38D].
   */
-  define_J0 : { len_IV } ( len_IV == IV) => [K] -> [len_IV] -> [128] -> [128]
+  define_J0 : { len_IV } ( ValidIV len_IV ) => [C::KeySize] -> [len_IV] -> [128] -> [128]
   define_J0 k iv H
     | len_IV == 96 => iv # (0 : [31]) # (1 : [1])
     | len_IV != 96 => GHASH`{len_IV /^ 128 + 1} H (iv # (0 : [s + 64]) # (`len_IV: [64]))
@@ -117,7 +109,7 @@ private
       type s = len_IV %^ 128  // Equivalently: 128 * len_IV /^ 128 - len_IV
 
   /**
-  * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+  * Multiplication Operation on Blocks, [NIST-SP-800-38D] Section
   * 6.3, Algorithm 1. This is optimized to use Cryptol's built-in `pmult` and
   * `pmod` functions. This operation is described using little-endian
   * notation, hence the `reverse`s.
@@ -128,7 +120,7 @@ private
                           <| 1 + x + x^^2 + x^^7 + x^^128|>)
 
   /**
-  * Multiplication Operation on Blocks, [NISTSP800-38D] Section
+  * Multiplication Operation on Blocks, [NIST-SP-800-38D] Section
   * 6.3. This matches the spec very closely.
   */
 
@@ -144,7 +136,7 @@ private
                 | Vi <- V ]
 
   /**
-  * GHASH Function, [NISTSP800-38D] Section 6.4, Algorithm 2.
+  * GHASH Function, [NIST-SP-800-38D] Section 6.4, Algorithm 2.
   */
 
   GHASH : {m} (fin m) => [128] -> [m * 128] -> [128]
@@ -154,7 +146,7 @@ private
   /**
   * The output of incrementing the right-most s bits of the bit
   * string X, regarded as the binary representation of an integer, by
-  * 1 modulo 2s, [NISTSP800-38D] Sections 4.2.2 and 6.2. Care was
+  * 1 modulo 2s, [NIST-SP-800-38D] Sections 4.2.2 and 6.2. Care was
   * taken here to ensure `s` could be zero.
   */
 
@@ -164,7 +156,7 @@ private
 
   /**
   * The bit string consisting of the s right-most bits
-  * of the bit string X, [NISTSP800-38D] Section 4.2.2.
+  * of the bit string X, [NIST-SP-800-38D] Section 4.2.2.
   */
 
   LSB : {s, a} (fin s, fin a, a >= s) => [a] -> [s]
@@ -172,14 +164,14 @@ private
 
   /**
   * The bit string consisting of the s left-most bits of
-  * the bit string X, [NISTSP800-38D] Section 4.2.2.
+  * the bit string X, [NIST-SP-800-38D] Section 4.2.2.
   */
 
   MSB : {s, a} (fin s, a >= s) => [a] -> [s]
   MSB X = take X
 
   /**
-  * GCTR Function, [NISTSP800-38D] Section 6.5, Algorithm 3.
+  * GCTR Function, [NIST-SP-800-38D] Section 6.5, Algorithm 3.
   */
 
   GCTR : {a} (fin a) => ([128] -> [128]) -> [128] -> [a] -> [a]

--- a/Primitive/Symmetric/Cipher/Authenticated/Instantiations/AES128_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/Instantiations/AES128_GCM.cry
@@ -1,0 +1,11 @@
+/*
+ * Instantiate GCM mode for AES 128.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
+module Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES128_GCM =
+    Primitive::Symmetric::Cipher::Authenticated::GCM {
+        Primitive::Symmetric::Cipher::Block::AES128
+    }
+

--- a/Primitive/Symmetric/Cipher/Authenticated/Instantiations/AES256_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/Instantiations/AES256_GCM.cry
@@ -1,0 +1,11 @@
+/*
+ * Instantiate GCM mode for AES 256.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
+module Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES256_GCM =
+    Primitive::Symmetric::Cipher::Authenticated::GCM {
+        Primitive::Symmetric::Cipher::Block::AES256
+    }
+

--- a/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
@@ -1,39 +1,33 @@
+import Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES128_GCM as AES128_GCM
+import Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES256_GCM as AES256_GCM
 
-// Cryptol instatiation of AES128-GCM and AES256-GCM, and test vectors for each.
-// Copyright (c) 2010-2024, Galois Inc.
-// www.cryptol.net
-// Author: Ajay Kumar Eeralla
+/*
+ Sources for test vectors:
 
-// Test vectors from http://luca-giuzzi.unibs.it/corsi/Support/papers-cryptography/gcm-spec.pdf
+ [GCM Submission]: David A. McGrew and John Viega. The Galois/Counter Mode of
+ Operation (GCM). Submission to NIST Modes of Operation Process. 2004.
+ Accessed from http://luca-giuzzi.unibs.it/corsi/Support/papers-cryptography/gcm-spec.pdf
 
-module Primitive::Symmetric::Cipher::Authenticated::AES_GCM where
-import `Primitive::Symmetric::Cipher::Authenticated::GCM
-import Primitive::Symmetric::Cipher::Block::AES128 as AES128
-import Primitive::Symmetric::Cipher::Block::AES256 as AES256
+ [OPENSSL]: The OpenSSL Project Authors. aesgcmtest.c. 2022.
+ Accessed from https://github.com/openssl/openssl/blob/master/test/aesgcmtest.c
+ */
 
-AES128_GCM_encrypt = GCM_AE `{K=128} {E=AES128::encrypt}
-AES128_GCM_decrypt = GCM_AD `{K=128} {E=AES128::encrypt}
-
-AES256_GCM_encrypt = GCM_AE `{K=256} {E=AES256::encrypt}
-AES256_GCM_decrypt = GCM_AD `{K=256} {E=AES256::encrypt}
-
-// GCM's symmetry property must hold for AES.
-// The other type parameter sizes are chosen arbitrarily.
-aesGcmIsSymmetric: [128] -> [96] -> [256] -> [0] -> Bool
-property aesGcmIsSymmetric key iv pt aad = gcmIsSymmetric `{T=128} { E=AES128::encrypt } key iv pt aad
-
-property AES_GCM_test_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
+// This can be `:prove`n quickly.
+// Source: [GCM Submission]
+property aes128_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         pt = []
         key = zero : [128]
         iv = zero : [96]
-        (ct, tag) = AES128_GCM_encrypt key iv pt []
-        dec = AES128_GCM_decrypt key iv ct [] tag
+        (ct, tag) = AES128_GCM::GCM_AE key iv pt []
+        dec = AES128_GCM::GCM_AD key iv ct [] tag
         expected_ct = [] : [0]
         expected_tag = 0x58e2fccefa7e3061367f1d57a4e7455a : [128]
         valid_dec = dec.valid && (dec.pt == pt)
 
-property AES_GCM_test_vector_1 =
+// This can be `:prove`n quickly.
+// Source: [GCM Submission]
+property aes128_vector_1 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key = zero
@@ -42,24 +36,28 @@ property AES_GCM_test_vector_1 =
         aad = []
         expected_ct = 0x0388dace60b6a392f328c2b971b2fe78 : [128]
         expected_tag = 0xab6e47d42cec13bdf53a67b21257bddf : [128]
-        (ct, tag) = AES128_GCM_encrypt key iv pt aad
-        dec = AES128_GCM_decrypt key iv ct aad tag
+        (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
+        dec = AES128_GCM::GCM_AD key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property AES_GCM_test_vector_2 =
+// This can be `:prove`n quickly.
+// Source: [GCM Submission]
+property aes128_vector_2 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
-        key = 0xfeffe9928665731c6d6a8f9467308308 : [128]
+        key = 0xfeffe9928665731c6d6a8f9467308308
         iv = 0xcafebabefacedbaddecaf888 : [96]
         pt = 0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255
         aad = []
         expected_ct = 0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985
         expected_tag = 0x4d5c2af327cd64a62cf35abd2ba6fab4 : [128]
-        (ct, tag) = AES128_GCM_encrypt key iv pt aad
-        dec = AES128_GCM_decrypt key iv ct aad tag
+        (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
+        dec = AES128_GCM::GCM_AD key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property AES_GCM_test_vector_3 =
+// This can be `:prove`n quickly.
+// Source: [GCM Submission]
+property aes128_vector_3 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key = 0xfeffe9928665731c6d6a8f9467308308
@@ -68,12 +66,13 @@ property AES_GCM_test_vector_3 =
         aad = 0xfeedfacedeadbeeffeedfacedeadbeefabaddad2
         expected_ct  = 0x42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091
         expected_tag = 0x5bc94fbc3221a5db94fae95ae7121a47
-        (ct, tag) = AES128_GCM_encrypt key iv pt aad
-        dec = AES128_GCM_decrypt key iv ct aad tag
+        (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
+        dec = AES128_GCM::GCM_AD key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-// A test case from aesgcmtest.c
-property AES_GCM_test_vector_4 =
+// This can be `:prove`n quickly.
+// Source: [OPENSSL]
+property aes256_vector_0 =
     ct == expected_ct /\ tag == expected_tag /\ valid_dec
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
@@ -82,11 +81,14 @@ property AES_GCM_test_vector_4 =
         aad   = 0x4d23c3cec334b49bdb370c437fec78de : [128]
         expected_ct   = 0xf7264413a84c0e7cd536867eb9f21736
         expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
-        (ct, tag) = AES256_GCM_encrypt key iv pt aad
-        dec = AES256_GCM_decrypt key iv ct aad tag
+        (ct, tag) = AES256_GCM::GCM_AE key iv pt aad
+        dec = AES256_GCM::GCM_AD key iv ct aad tag
         valid_dec = dec.valid && (dec.pt == pt)
 
-property AES_GCM_invalid_test_vector =
+// This can be `:prove`n quickly.
+// Source: Modified from [OPENSSL]. I just borked the tag to make sure decryption fails if
+// the tag is wrong.
+property aes256_invalid_vector_1 =
     ct == expected_ct /\ tag == expected_tag /\ ~dec.valid
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
@@ -96,5 +98,5 @@ property AES_GCM_invalid_test_vector =
         expected_ct   = 0xf7264413a84c0e7cd536867eb9f21736
         expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
         invalid_tag  = 0x67ba0510262ae487d737ee6298f77888
-        (ct, tag) = AES256_GCM_encrypt key iv pt aad
-        dec = AES256_GCM_decrypt key iv ct aad invalid_tag
+        (ct, tag) = AES256_GCM::GCM_AE key iv pt aad
+        dec = AES256_GCM::GCM_AD key iv ct aad invalid_tag

--- a/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
@@ -14,7 +14,7 @@ import Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES256_GCM a
 
 // This can be `:prove`n quickly.
 // Source: [GCM Submission]
-property aes128_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
+property aes128_vector_0 = ct == expected_ct /\ tag == expected_tag /\ is_symmetric
     where
         pt = []
         key = zero : [128]
@@ -23,12 +23,15 @@ property aes128_vector_0 = ct == expected_ct /\ tag == expected_tag /\ valid_dec
         dec = AES128_GCM::GCM_AD key iv ct [] tag
         expected_ct = [] : [0]
         expected_tag = 0x58e2fccefa7e3061367f1d57a4e7455a : [128]
-        valid_dec = dec.valid && (dec.pt == pt)
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
+
 
 // This can be `:prove`n quickly.
 // Source: [GCM Submission]
 property aes128_vector_1 =
-    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    ct == expected_ct /\ tag == expected_tag /\ is_symmetric
     where
         key = zero
         iv = zero : [96]
@@ -38,12 +41,15 @@ property aes128_vector_1 =
         expected_tag = 0xab6e47d42cec13bdf53a67b21257bddf : [128]
         (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
         dec = AES128_GCM::GCM_AD key iv ct aad tag
-        valid_dec = dec.valid && (dec.pt == pt)
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
+
 
 // This can be `:prove`n quickly.
 // Source: [GCM Submission]
 property aes128_vector_2 =
-    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    ct == expected_ct /\ tag == expected_tag /\ is_symmetric
     where
         key = 0xfeffe9928665731c6d6a8f9467308308
         iv = 0xcafebabefacedbaddecaf888 : [96]
@@ -53,12 +59,15 @@ property aes128_vector_2 =
         expected_tag = 0x4d5c2af327cd64a62cf35abd2ba6fab4 : [128]
         (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
         dec = AES128_GCM::GCM_AD key iv ct aad tag
-        valid_dec = dec.valid && (dec.pt == pt)
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
+
 
 // This can be `:prove`n quickly.
 // Source: [GCM Submission]
 property aes128_vector_3 =
-    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    ct == expected_ct /\ tag == expected_tag /\ is_symmetric
     where
         key = 0xfeffe9928665731c6d6a8f9467308308
         pt  = 0xd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39
@@ -68,12 +77,15 @@ property aes128_vector_3 =
         expected_tag = 0x5bc94fbc3221a5db94fae95ae7121a47
         (ct, tag) = AES128_GCM::GCM_AE key iv pt aad
         dec = AES128_GCM::GCM_AD key iv ct aad tag
-        valid_dec = dec.valid && (dec.pt == pt)
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
+
 
 // This can be `:prove`n quickly.
 // Source: [OPENSSL]
 property aes256_vector_0 =
-    ct == expected_ct /\ tag == expected_tag /\ valid_dec
+    ct == expected_ct /\ tag == expected_tag /\ is_symmetric
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
         iv    = 0x99aa3e68ed8173a0eed06684 : [96]
@@ -83,13 +95,15 @@ property aes256_vector_0 =
         expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
         (ct, tag) = AES256_GCM::GCM_AE key iv pt aad
         dec = AES256_GCM::GCM_AD key iv ct aad tag
-        valid_dec = dec.valid && (dec.pt == pt)
+        is_symmetric = case dec of
+          Some actual_pt -> pt == actual_pt
+          None -> False
 
 // This can be `:prove`n quickly.
 // Source: Modified from [OPENSSL]. I just borked the tag to make sure decryption fails if
 // the tag is wrong.
 property aes256_invalid_vector_1 =
-    ct == expected_ct /\ tag == expected_tag /\ ~dec.valid
+    ct == expected_ct /\ tag == expected_tag /\ requires_symmetry
     where
         key   = 0xeebc1f57487f51921c0465665f8ae6d1658bb26de6f8a069a3520293a572078f : [256]
         iv    = 0x99aa3e68ed8173a0eed06684 : [96]
@@ -99,4 +113,6 @@ property aes256_invalid_vector_1 =
         expected_tag  = 0x67ba0510262ae487d737ee6298f77e0c
         invalid_tag  = 0x67ba0510262ae487d737ee6298f77888
         (ct, tag) = AES256_GCM::GCM_AE key iv pt aad
-        dec = AES256_GCM::GCM_AD key iv ct aad invalid_tag
+        requires_symmetry = case (AES256_GCM::GCM_AD key iv ct aad invalid_tag) of
+            Some _ -> False
+            None -> True

--- a/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/Tests/TestAES_GCM.cry
@@ -1,3 +1,9 @@
+/*
+ * Test vectors for AES with GCM mode, for multiple key sizes.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
 import Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES128_GCM as AES128_GCM
 import Primitive::Symmetric::Cipher::Authenticated::Instantiations::AES256_GCM as AES256_GCM
 

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -1,28 +1,35 @@
-:l AES_GCM.cry
+:l Tests/TestAES_GCM.cry
 
-:prove AES_GCM_test_vector_0
-:prove AES_GCM_test_vector_1
-:prove AES_GCM_test_vector_2
-:prove AES_GCM_test_vector_3
-:prove AES_GCM_test_vector_4
-:prove AES_GCM_invalid_test_vector
+:prove aes128_vector_0
+:prove aes128_vector_1
+:prove aes128_vector_2
+:prove aes128_vector_3
+
+:prove aes256_vector_0
+:prove aes256_invalid_vector_1
 
 // The following checks do not really provide any significant formal
 // verification because they check so little of the sample space.
 // They each take a long time to `:prove` and would likely require
 // manual modification to prove in a reasonable amount of time.
 
-// These properties can be checked manually; one of the APIs calls the other.
-// They take more than an hour to `:prove`.
-:check aesGcmDecryptionApisAreEquivalent
-:check aesGcmEncryptionApisAreEquivalent
 
-// This property is independent of the type parameters but we have to specify
-// them anyway.
-// It takes more than 25 minutes to `:prove`.
-:check dotAndMultAreEquivalent `{K=128, IV=96, AAD=0, T=128} {E=AES128::encrypt}
+:l Instantiations/AES128_GCM.cry
 
 // Make sure that decryption is the inverse of encryption
 // This property takes more than 20 minutes to `:prove`.
 // It's also spot-checked in the test vectors
-:check aesGcmIsSymmetric
+// Here, we just pick a fixed set of parameters, but it should be true
+// for all valid tag, aad, and plaintext lengths.
+// - P = 256 because we want to test the block chaining, so we need at least 2
+// - IV = 96 because it's the shortest allowable value
+// - AAD = 5 because we want to make sure it's incorporated
+:check gcmIsSymmetric `{AAD=5, P=256, IV=96}
+
+// This takes more than 25 minutes to `:prove`.
+:check dotAndMultAreEquivalent
+
+// Repeat the above checks for AES256
+:l Instantiations/AES256_GCM.cry
+:check gcmIsSymmetric `{AAD=5, P=256, IV=96}
+:check dotAndMultAreEquivalent

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -28,8 +28,11 @@
 
 // This takes more than 25 minutes to `:prove`.
 :check dotAndMultAreEquivalent
+// This is a property of one of the internal methods for GCM
+:prove emptyInputProducesEmptyOutputGCTR
 
 // Repeat the above checks for AES256
 :l Instantiations/AES256_GCM.cry
 :check gcmIsSymmetric `{AAD=8, P=256, IV=96}
 :check dotAndMultAreEquivalent
+:prove emptyInputProducesEmptyOutputGCTR

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -1,3 +1,10 @@
+//
+// Batch file to prove & check properties of AES-GCM, with various key sizes.
+//
+// @copyright Galois, Inc.
+// @author Marcella Hastings <marcella@galois.com>
+//
+
 :l Tests/TestAES_GCM.cry
 
 :prove aes128_vector_0

--- a/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
+++ b/Primitive/Symmetric/Cipher/Authenticated/aes_gcm.bat
@@ -24,12 +24,12 @@
 // - P = 256 because we want to test the block chaining, so we need at least 2
 // - IV = 96 because it's the shortest allowable value
 // - AAD = 5 because we want to make sure it's incorporated
-:check gcmIsSymmetric `{AAD=5, P=256, IV=96}
+:check gcmIsSymmetric `{AAD=8, P=256, IV=96}
 
 // This takes more than 25 minutes to `:prove`.
 :check dotAndMultAreEquivalent
 
 // Repeat the above checks for AES256
 :l Instantiations/AES256_GCM.cry
-:check gcmIsSymmetric `{AAD=5, P=256, IV=96}
+:check gcmIsSymmetric `{AAD=8, P=256, IV=96}
 :check dotAndMultAreEquivalent


### PR DESCRIPTION
Addresses #78, except for making the spec literate (moved to #87).

This PR aims to improve the code quality, documentation, and NIST spec adherence of GCM mode (and its instantiations for AES). It builds on the paradigms (using `CipherInterface`) added in #83. 

I identified all the issues that I addressed here; if others would like to take a pass of the NIST spec and/or this implementation and identify other areas for improvement, I would welcome that feedback.

---

I have one open / blocking question: There's a duplicate version of AES256-GCM in the repo. It looks like [AES_256_GCM.cry](https://github.com/GaloisInc/cryptol-specs/blob/master/Primitive/Symmetric/Cipher/Authenticated/AES_256_GCM.cry) is used in [the aws-lc-verification repo](https://github.com/search?q=repo%3Aawslabs%2Faws-lc-verification%20AES_256_GCM&type=code). Should keep what I assume is a SAW-optimized version of the spec in this repo? It's not written with respect to the NIST spec (I assume because the NIST spec is not efficient) and I would have to spend some time to audit it and determine whether it's the same as the other version we have. 

I believe there are several other cases where this repo contains duplicate, SAW-optimized versions of algorithms. I'm looking for guidance on what to do in these cases. The options I see are:
1. Remove the SAW-optimized versions from the repo; perhaps move them to another location. Add documentation somewhere at the top level of cryptol-specs to note that this repo aims to add spec-conformant versions of algorithms and they may need to be optimized much more to be used in conjunction with SAW / to actually verify an implementation.
2. Keep the SAW-optimized versions in the repo. Add documentation on each version explaining the use case; add docs at the top level of cryptol-specs to explain the need for multiple versions of things.

Pinging @RyanGlScott and @mccleeary-galois specifically; others also welcome to weigh in.
