### PR TITLE
Add parameterization to key wrap modes

### DIFF
--- a/Primitive/Symmetric/Cipher/Block/Instantiations/AES256_KeyWrap.cry
+++ b/Primitive/Symmetric/Cipher/Block/Instantiations/AES256_KeyWrap.cry
@@ -1,0 +1,9 @@
+/*
+ * Instantiate KeyWrap mode for AES 256.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
+module Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrap =
+    Primitive::Symmetric::Cipher::Block::Modes::AESKeyWrap where
+        type AESKeySize' = 256

--- a/Primitive/Symmetric/Cipher/Block/Instantiations/AES256_KeyWrapPadded.cry
+++ b/Primitive/Symmetric/Cipher/Block/Instantiations/AES256_KeyWrapPadded.cry
@@ -1,0 +1,9 @@
+/*
+ * Instantiate KeyWrapPadded mode for AES 256.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
+module Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrapPadded =
+    Primitive::Symmetric::Cipher::Block::Modes::AESKeyWrapPadded where
+        type AESKeySize' = 256

--- a/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrap.cry
+++ b/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrap.cry
@@ -1,7 +1,11 @@
 // Cryptol AES Key Wrap Implementation
-// Copyright (c) 2020, Galois Inc.
+//
+// @copyright Galois Inc.
+// @author Brett Boston
+// @author Ryan Scott <rscott@galois.com>
+// @author Marcella Hastings <marcella@galois.com>
 // www.cryptol.net
-
+//
 // This is a close implementation of RFC 3394:
 // https://tools.ietf.org/html/rfc3394
 // RFC 3394 provides two equivalent descriptions of AES Key Wrap, one using
@@ -9,14 +13,20 @@
 // the index-based algorithm description as that description is more similar
 // to the BoringSSL AES Key Wrap implementation.
 //
-// One important deviation: this is currently instantiated only for AES256;
-// the RFC supports all three standardized AES key sizes.
-//
 
-module Primitive::Symmetric::Cipher::Block::AESKeyWrap where
-import Primitive::Symmetric::Cipher::Block::AES256 as AES256
+module Primitive::Symmetric::Cipher::Block::Modes::AESKeyWrap where
 
-type AESKeySize = AES256::KeySize
+parameter
+  // This constraint enforces the standard key sizes of 128, 192, and
+  // 256 bits.
+  type AESKeySize' : #
+  type constraint (fin AESKeySize', AESKeySize' % 64 == 0, AESKeySize' / 64 >= 2, AESKeySize' / 64 <= 4)
+
+import Primitive::Symmetric::Cipher::Block::AES_specification as AES where
+  type KeySize' = AESKeySize'
+
+// Make the key size parameter available outside the module
+type AESKeySize = AESKeySize'
 
 // Default intial value (Section 2.2.3)
 DefaultIV : [8][8]
@@ -83,7 +93,7 @@ private
   wrapBlock : {n} (fin n, width n <= 64) =>
               [AESKeySize] -> ([64], [n][64]) -> [64] -> [64] -> ([64], [n][64])
   wrapBlock key (A, R) j i = (A', R')
-    where B  = AES256::encrypt key (A # (R @ (i-1)))
+    where B  = AES::encrypt key (A # (R @ (i-1)))
           A' = (take`{64} B) ^ (((`n : [64]) * j) + i)
           R' = update R (i-1) (drop`{64} B)
 
@@ -91,7 +101,7 @@ private
   unwrapBlock : {n} (fin n, width n <= 64) =>
                 [AESKeySize] -> ([64], [n][64]) -> [64] -> [64] -> ([64], [n][64])
   unwrapBlock key (A, R) j i = (A', R')
-    where B  = AES256::decrypt key ((A ^ (((`n : [64]) * j) + i)) # (R @ (i-1)))
+    where B  = AES::decrypt key ((A ^ (((`n : [64]) * j) + i)) # (R @ (i-1)))
           A' = take`{64} B
           R' = update R (i-1) (drop`{64} B)
 

--- a/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrapPadded.cry
+++ b/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrapPadded.cry
@@ -1,18 +1,31 @@
 // Cryptol AES Key Wrap Padded Implementation
-// Copyright (c) 2020, Galois Inc.
+//
+// @copyright Galois Inc.
+// @author Brett Boston
+// @author Ryan Scott <rscott@galois.com>
+// @author Marcella Hastings <marcella@galois.com>
 // www.cryptol.net
 
 // This is a close implementation of RFC 5649:
 // https://tools.ietf.org/html/rfc5649
 //
-// One important deviation: this is currently instantiated only for AES256;
-// the RFC supports all three standardized AES key sizes.
 
-module Primitive::Symmetric::Cipher::Block::AESKeyWrapPadded where
-import Primitive::Symmetric::Cipher::Block::AES256 as AES256
-import Primitive::Symmetric::Cipher::Block::AESKeyWrap
+module Primitive::Symmetric::Cipher::Block::Modes::AESKeyWrapPadded where
 
-type AESKeySize = AES256::KeySize
+parameter
+  // This constraint enforces the standard key sizes of 128, 192, and
+  // 256 bits.
+  type AESKeySize' : #
+  type constraint (fin AESKeySize', AESKeySize' % 64 == 0, AESKeySize' / 64 >= 2, AESKeySize' / 64 <= 4)
+
+// Make the key size type available outside the module.
+type AESKeySize = AESKeySize'
+
+import Primitive::Symmetric::Cipher::Block::Modes::AESKeyWrap where
+  type AESKeySize' = AESKeySize
+
+import Primitive::Symmetric::Cipher::Block::AES_specification as AES where
+  type KeySize' = AESKeySize'
 
 // Most significant bits of alternate initial value (Section 3)
 AlternativeIV : [4][8]
@@ -32,7 +45,7 @@ aesWrapKeyPadded key iv plaintext =
   // If padded plaintext is 8 bytes, encrypt in AEC ECB mode.  The `drop` and
   // append of `zero` have no effect at runtime and exist to make the types
   // work out, as the type checker cannot deduce that `n <= 8` in this branch.
-  then (split (AES256::encrypt key (drop (join (AIV # P))))) # zero
+  then (split (AES::encrypt key (drop (join (AIV # P))))) # zero
   // Otherwise perform standard key wrap algorithm on padded plaintext.  The
   // `drop` and append of `zero` have runtime effect and exist to make the
   // types work out, as the type checker cannot deduce that `n >= 16` in this
@@ -65,7 +78,7 @@ aesUnwrapKeyPadded key iv ciphertext = if valid
         // and append of `zero` have no effect at runtime and exist to make the
         // types work out, as the type checker cannot deduce that `n == 16` in
         // this branch.
-        then (split (AES256::decrypt key (drop (join ciphertext)))) # zero
+        then (split (AES::decrypt key (drop (join ciphertext)))) # zero
         // Otherwise perform the standard key unwrap algorithm.  The `drop`
         // and append of `zero` have no effect at runtime and exist to make the
         // types work out, as the type checker cannot deduce that `n >= 24` in

--- a/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrap.cry
+++ b/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrap.cry
@@ -1,6 +1,6 @@
 module Primitive::Symmetric::Cipher::Block::Tests::TestAESKeyWrap where
 
-import Primitive::Symmetric::Cipher::Block::AESKeyWrap
+import Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrap
 
 // This section contains tests of the Key Wrap specifications using test
 // vectors from Section 4 of RFC 3394.

--- a/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrapPadded.cry
+++ b/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrapPadded.cry
@@ -1,6 +1,6 @@
 module Primitive::Symmetric::Cipher::Block::Tests::TestAESKeyWrapPadded where
 
-import Primitive::Symmetric::Cipher::Block::AESKeyWrapPadded
+import Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrapPadded
 
 testUnwrap : {a, b} ( fin a
                     , b <= a - 8


### PR DESCRIPTION
Closes #81.

A snack of a PR before the holiday. This adds a key size parameter to AES's key wrap modes so that it supports all the key sizes from the spec. Also slightly rearranges things to match the slowly changing directory structure for block ciphers, which separates modes of operation from instantiations of modes with specific ciphers.