### PR TITLE
ci: add copyright check

### DIFF
--- a/.github/workflows/copyright_check.yml
+++ b/.github/workflows/copyright_check.yml
@@ -1,0 +1,21 @@
+name: Copyright check
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  copyright-check:
+    runs-on: ubuntu-latest
+    steps:
+      - id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: "Run copyright script"
+        run: |
+          # The filter excludes files that were removed
+          changed_files=$(git diff --name-only --diff-filter ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }})
+          # NB: this will fail if any files have spaces in the names
+          bash scripts/check_copyright.sh $changed_files
+

--- a/.github/workflows/copyright_check.yml
+++ b/.github/workflows/copyright_check.yml
@@ -1,3 +1,9 @@
+# Checks that every updated file has an appropriate copyright notice.
+#
+# @copyright Galois, Inc
+# @author Marcella Hastings <marcella@galois.com>
+#
+
 name: Copyright check
 on:
   pull_request:

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -8,8 +8,24 @@
 COPYRIGHT="@copyright Galois"
 AUTHOR="@author .*@galois.com>"
 
-# I think this will fail if any file names have spaces in them
-FILES=$@
+# Filters the set of changed files to only those we want copyright
+# notices on -- files that likely have cryptol code in them.
+#
+# Skips images, pdfs, bibliographies, Makefiles, and infrastructure
+# (configs, ymls, dotfiles, etc.).
+interesting_files() {
+    for fname in $@ ; do
+        case $fname in
+            README.md) continue ;;
+
+            *.cry | *.tex | *.md | *.bat | *.awk)
+                echo $fname ;;
+        esac
+    done
+}
+
+# This will fail if any file names have spaces in them
+FILES=$(interesting_files $@)
 echo -e "Checking the following files: $FILES"
 
 missing_copyright=""

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
+# Checks that every file indicated has an appropriate copyright notice.
+#
+# @copyright Galois, Inc
+# @author Marcella Hastings <marcella@galois.com>
+#
 
 COPYRIGHT="@copyright Galois"
 AUTHOR="@author .*@galois.com>"
 
-# The get-changed-files Github Action requires filenames have no spaces in them.
+# I think this will fail if any file names have spaces in them
 FILES=$@
 echo -e "Checking the following files: $FILES"
 

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+COPYRIGHT="@copyright Galois"
+AUTHOR="@author .*@galois.com>"
+
+# The get-changed-files Github Action requires filenames have no spaces in them.
+FILES=$@
+echo -e "Checking the following files: $FILES"
+
+missing_copyright=""
+missing_author=""
+for file in $FILES ; do
+    if ! (grep -qr "${COPYRIGHT}" $file); then
+        missing_copyright+="  $file\n"
+    fi
+
+    if !(grep -qr "${AUTHOR}" $file); then
+        missing_author+="  $file\n"
+    fi
+done
+
+failed=0
+if [ ! -z "$missing_copyright" ]; then
+    failed=1
+    echo "Missing copyright notice on the following changed files:"
+    echo -e "Add a comment containing '$COPYRIGHT Inc' to each file."
+    echo -e "$missing_copyright"
+fi
+
+if [ ! -z "$missing_author" ]; then
+    failed=1
+    echo "Missing author on the following changed files:"
+    echo "Add a comment containing '@author Name <email@galois.com>' to each file."
+    echo -e "$missing_author"
+fi
+
+exit $failed


### PR DESCRIPTION
Closes #89.

Checks that any files modified, added, etc. in a PR have the appropriate copyright notice on top. You can see an example of a failed and a successful run on the two commits.