### PR TITLE
CI: update version for actions/checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,12 @@ jobs:
       run: |
         apt update
         apt install -y git
+
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
     - name: Cryptol Version
       run: cryptol --version
+
     - name: Check Cryptol Files
       run: bash scripts/load_all_cry_files.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,9 @@
-name: Cryptol
+name: Cryptol typecheck
 on:
   push:
     branches:
       - master
   pull_request:
-    branches:
-      - master
-  schedule:
-    - cron: "0 10 * * *" # 10am UTC -> 2/3am PST
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Following up on [this comment](https://github.com/GaloisInc/cryptol-specs/pull/90#issuecomment-2215069436): I believe the check-build ci run wasn't going because our version of the checkout action was deprecated.