### PR TITLE
Add Fast NTT and Inverse NTT for ML-KEM

### DIFF
--- a/Common/ntt.cry
+++ b/Common/ntt.cry
@@ -1,9 +1,11 @@
 /* Recursive NTT
 
-   John D. Ramsdell -- The MITRE Corporation -- May 2022
+   @author John D. Ramsdell -- The MITRE Corporation -- May 2022
 
-   Copyright (c) 2023 The MITRE Corporation.  Distributed under a
-   standard, three-clause BSD license shown in ntt_license.txt. */
+   @copyright 2023 The MITRE Corporation.
+   @license Distributed under a standard, three-clause BSD license
+   shown in ntt_license.txt.
+*/
 
 /* It type checks, and it succeeds in meeting the ntt_correct property
    below which says that the inverse ntt applied to the ntt is the

--- a/Common/ntt.cry
+++ b/Common/ntt.cry
@@ -85,6 +85,8 @@ roots = iterate ((*) (r * r)) 1
 /**
  * An O(n log n) number theortic transform for Dilithium.
  */
+import Common::utils (coerceSize)
+
 ntt : [nn]Fld -> [nn]Fld
 ntt a = ntt_r`{lg2 nn} 0 a
 
@@ -98,9 +100,6 @@ ntt_r depth a =
       (lft, rht) = shuffle (coerceSize a)
       even = ntt_r`{max 1 n - 1} (depth + 1) lft
       odd = ntt_r`{max 1 n - 1} (depth + 1) rht
-
-coerceSize : {m, n, a} [m]a -> [n]a
-coerceSize xs = [ xs @ i | i <- [0 .. <n]]
 
 /**
  * Group even indices in first half and odd indices in second half.

--- a/Common/utils.cry
+++ b/Common/utils.cry
@@ -71,3 +71,6 @@ mp_mod_inv c = if c == 0 then error "Zero does not have a multiplicative inverse
 // Note, this property will only hold when the modulus is prime
 mp_mod_inv_correct : {a} (fin a, a >=2) => Z a -> Bit
 property mp_mod_inv_correct x = x != 0 ==> x * mp_mod_inv x == 1
+
+coerceSize : {m, n, a} [m]a -> [n]a
+coerceSize xs = [ xs @ i | i <- [0 .. <n]]

--- a/Common/utils.cry
+++ b/Common/utils.cry
@@ -1,3 +1,18 @@
+/*
+
+General utility functions for use across implementations.
+
+@copyright Galois, Inc
+@copyright Amazon.com or its affiliates.
+
+@author Sean Weaver
+@author Nichole Schmanski <nls@galois.com>
+@author Rob Dockins
+@author Andrei Stefanescu
+@editor Ryan Scott <rscott@galois.com>
+@editor Rod Chapman <rodchap@amazon.com>
+
+*/
 module Common::utils where
 
 while : {a} (a -> Bit) -> (a -> a) -> a -> a

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem1024.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem1024.cry
@@ -1,3 +1,10 @@
+/*
+@copyright Galois, Inc
+@author Marios Georgiou <marios@galois.com>
+
+@copyright Amazon.com or its affiliates.
+@editor Rod Chapman <rodchap@amazon.com>
+*/
 module ml_kem1024 = specification where
 
 type k = 4

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem1024.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem1024.cry
@@ -1,6 +1,5 @@
 module ml_kem1024 = specification where
 
-type q = 3329
 type k = 4
 type eta_1 = 2
 type eta_2 = 2

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem512.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem512.cry
@@ -1,3 +1,11 @@
+/*
+@copyright Galois, Inc
+@author Marios Georgiou <marios@galois.com>
+
+@copyright Amazon.com or its affiliates.
+@editor Rod Chapman <rodchap@amazon.com>
+*/
+
 module ml_kem512 = specification where
 
 type k = 2

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem512.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem512.cry
@@ -1,6 +1,5 @@
 module ml_kem512 = specification where
 
-type q = 3329
 type k = 2
 type eta_1 = 3
 type eta_2 = 2

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem768.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem768.cry
@@ -1,3 +1,10 @@
+/*
+@copyright Galois, Inc
+@author Marios Georgiou <marios@galois.com>
+
+@copyright Amazon.com or its affiliates.
+@editor Rod Chapman <rodchap@amazon.com>
+*/
 module ml_kem768 = specification where
 
 type k = 3

--- a/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem768.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/ml_kem768.cry
@@ -1,6 +1,5 @@
 module ml_kem768 = specification where
 
-type q = 3329
 type k = 3
 type eta_1 = 2
 type eta_2 = 2

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -135,6 +135,12 @@ NaiveNTTInv f = [term*(recip 128) | term <- ParametricNTTInv f (recip zeta)]
 //////////////////////////////////////////////////////////////
 // This section specifies fast O(N log N) NTT and Inverse NTT
 //
+// A readable explanation of the derivation of this form of
+// the NTT is in "A Complete Beginner Guide to the Number
+// Theoretic Transform (NTT)" by Ardianto Satriawan,
+// Rella Mareta, and Hanho Lee. Available from:
+//    https://eprint.iacr.org/2024/585
+//
 // This section Copyright Amazon.com, Inc. or its affiliates.
 //////////////////////////////////////////////////////////////
 

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -237,47 +237,57 @@ fast_invntt v = mul_recip128 (fast_invnttl v 1)
 // Properties and proofs of Naive and Fast NTT
 //////////////////////////////////////////////////////////////
 
-// This property demonstrates that NaiveNTT is self-inverting
-// ```
-// :prove NaiveNTT_Inverts
-// ```
-//
+/**
+ * This property demonstrates that NaiveNTT is self-inverting
+ * ```
+ * :prove NaiveNTT_Inverts
+ * ```
+ */
 NaiveNTT_Inverts : Z_q_256 -> Bit
 property NaiveNTT_Inverts f =  NaiveNTTInv (NaiveNTT f) == f
 
-// This property demonstrates that NaiveNTTInv is self-inverting
-// ```
-// :prove NaiveNTTInv_Inverts
-// ```
-//
+/**
+ * This property demonstrates that NaiveNTTInv is self-inverting
+ * ```
+ * :prove NaiveNTTInv_Inverts
+ * ```
+ */
 NaiveNTTInv_Inverts : Z_q_256 -> Bit
 property NaiveNTTInv_Inverts f =  NaiveNTT (NaiveNTTInv f) == f
 
-// This property demonstrates that `fast_ntt` is the inverse of `fast_invntt`.
-// ```
-// :prove fast_ntt_inverts
-// ```
+/**
+ * This property demonstrates that `fast_ntt` is the inverse of `fast_invntt`.
+ * ```
+ * :prove fast_ntt_inverts
+ * ```
+ */
 fast_ntt_inverts    : Z_q_256 -> Bit
 property fast_ntt_inverts    f =  fast_invntt (fast_ntt f)    == f
 
-// This property demonstrates that `fast_invntt` is the inverse of `fast_ntt`.
-// ```
-// :prove fast_invntt_inverts
-// ```
+/**
+ * This property demonstrates that `fast_invntt` is the inverse of `fast_ntt`.
+ * ```
+ * :prove fast_invntt_inverts
+ * ```
+ */
 fast_invntt_inverts : Z_q_256 -> Bit
 property fast_invntt_inverts f =  fast_ntt    (fast_invntt f) == f
 
-// This property demonstrates that `naive_ntt` is equivalent to `fast_ntt`.
-// ```
-// :prove naive_fast_ntt_equiv
-// ```
+/**
+ * This property demonstrates that `naive_ntt` is equivalent to `fast_ntt`.
+ * ```
+ * :prove naive_fast_ntt_equiv
+ * ```
+ */
 naive_fast_ntt_equiv : Z_q_256 -> Bit
 property naive_fast_ntt_equiv f =  NaiveNTT f == fast_ntt f
 
-// This property demonstrates that `naive_invntt` is equivalent to `fast_invntt`.
-// ```
-// :prove naive_fast_invntt_equiv
-// ```
+/**
+ * This property demonstrates that `naive_invntt` is equivalent to `fast_invntt`.
+ * ```
+ * :prove naive_fast_invntt_equiv
+ * ```
+ */
 naive_fast_invntt_equiv : Z_q_256 -> Bit
 property naive_fast_invntt_equiv f =  NaiveNTTInv f == fast_invntt f
 

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -1,3 +1,12 @@
+/*
+ML-KEM cipher with a fast NTT implementation.
+
+@copyright Galois, Inc
+@author Marios Georgiou <marios@galois.com>
+
+@copyright Amazon.com or its affiliates.
+@author Rod Chapman <rodchap@amazon.com>
+*/
 module specification where
 
 type q = 3329

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -197,7 +197,8 @@ fast_nttl v k
   | lv == 2 => ct_butterfly`{lv,lv-1} v (zeta_expc@k)
 
   // Recursive case. Butterfly what we have, then recurse on each half,
-  // concatenate the results and return
+  // concatenate the results and return. As above, we need coerceSize
+  // here (twice) to satisfy the type checker.
   | lv  > 2 => coerceSize ((fast_nttl`{lv-1} s0 (k * 2)) #
                            (fast_nttl`{lv-1} s1 (k * 2 + 1)))
                 where
@@ -242,7 +243,8 @@ fast_invnttl v k
   | lv == 2 => gs_butterfly`{lv,lv-1} v (zeta_expc@k)
 
   // Recursive case. Recurse on each half,
-  // concatenate the results, butterfly that, and return
+  // concatenate the results, butterfly that, and return.
+  // As above, we need coerceSize here (twice) to satisfy the type checker.
   | lv  > 2 => gs_butterfly`{lv,lv-1} t (zeta_expc@k)
                 where
                   // Split t into two halves s0 and s1

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -1,5 +1,7 @@
 module specification where
 
+type q = 3329
+
 type Byte = [8]
 
 BytesToBits : {ell} (fin ell, ell > 0) => [ell]Byte -> [ell*8]Bit
@@ -32,7 +34,7 @@ property concatPlusCorrect a b = concatPlus a b == b
 
 type n = 256
 
-// Z is a Cryptol primitive such that Z q represents integers mod q that are 
+// Z is a Cryptol primitive such that Z q represents integers mod q that are
 // closed under arithmetic operations
 type Z_q_256 = [n](Z q)
 
@@ -58,7 +60,7 @@ property rounding = ((roundAway(1.5) == 2) && (roundAway(1.4) == 1))
 Compress'' : {d} (d < lg2 q) => Z q -> [d]
 Compress'' x = fromInteger(roundAway(((2^^`d)/.`q) * fromInteger(fromZ(x))) % 2^^`d)
 
-Decompress'' : {d} (d < lg2 q) => [d] -> Z q 
+Decompress'' : {d} (d < lg2 q) => [d] -> Z q
 Decompress'' x = fromInteger(roundAway(((`q)/.(2^^`d))*fromInteger(toInteger(x))))
 
 B_q : {d} (d < lg2 q) => Integer
@@ -107,6 +109,12 @@ BitRev7 : [8] -> [8]
 BitRev7 = reverse
 
 
+//////////////////////////////////////////////////////////////
+// This section specifies a naive O(N**2) NTT and Inverse NTT
+//
+// A "fast" O(N log N) version is below, followed by a
+// proof of their equivalence
+//////////////////////////////////////////////////////////////
 
 ParametricNTT : Z_q_256 -> (Z q) -> Z_q_256
 ParametricNTT f root = join[[f2i i, f2iPlus1 i] | i <- [0 .. 127]]
@@ -118,16 +126,182 @@ ParametricNTTInv f root = join[[f2i i, f2iPlus1 i] | i <- [0 .. 127]]
   where f2i i      = sum [f@(2*j)   * root ^^ ((2*(BitRev7 j >> 1)+1)*i) | j <- [0 .. 127]]
         f2iPlus1 i = sum [f@(2*j+1) * root ^^ ((2*(BitRev7 j >> 1)+1)*i) | j <- [0 .. 127]]
 
+NaiveNTT : Z_q_256 -> Z_q_256
+NaiveNTT f = ParametricNTT f zeta
+
+NaiveNTTInv : Z_q_256 -> Z_q_256
+NaiveNTTInv f = [term*(recip 128) | term <- ParametricNTTInv f (recip zeta)]
+
+//////////////////////////////////////////////////////////////
+// This section specifies fast O(N log N) NTT and Inverse NTT
+//
+// This section Copyright Amazon.com, Inc. or its affiliates.
+//////////////////////////////////////////////////////////////
+
+import Common::utils (coerceSize)
+
+// Simple lookup table for Zeta value given K
+zeta_expc  : [128](Z q)
+zeta_expc = [ 1, 1729, 2580, 3289, 2642, 630, 1897, 848,
+              1062, 1919, 193, 797, 2786, 3260, 569, 1746,
+              296, 2447, 1339, 1476, 3046, 56, 2240, 1333,
+              1426, 2094, 535, 2882, 2393, 2879, 1974, 821,
+              289, 331, 3253, 1756, 1197, 2304, 2277, 2055,
+              650, 1977, 2513, 632, 2865, 33, 1320, 1915,
+              2319, 1435, 807, 452, 1438, 2868, 1534, 2402,
+              2647, 2617, 1481, 648, 2474, 3110, 1227, 910,
+              17, 2761, 583, 2649, 1637, 723, 2288, 1100,
+              1409, 2662, 3281, 233, 756, 2156, 3015, 3050,
+              1703, 1651, 2789, 1789, 1847, 952, 1461, 2687,
+              939, 2308, 2437, 2388, 733, 2337, 268, 641,
+              1584, 2298, 2037, 3220, 375, 2549, 2090, 1645,
+              1063, 319, 2773, 757, 2099, 561, 2466, 2594,
+              2804, 1092, 403, 1026, 1143, 2150, 2775, 886,
+              1722, 1212, 1874, 1029, 2110, 2935, 885, 2154 ]
+
+// Fast recursive CT-NTT
+ct_butterfly :
+    {m, hm}
+    (m >= 2, m <= 8, hm >= 1, hm <= 7, hm == m - 1) =>
+    [2^^m](Z q) -> (Z q) -> [2^^m](Z q)
+ct_butterfly v z = new_v
+  where
+    halflen = 2^^`hm
+    lower, upper : [2^^hm](Z q)
+    lower@x = v@x + z * v@(x + halflen)
+    upper@x = v@x - z * v@(x + halflen)
+    new_v = coerceSize (lower # upper)
+
+fast_nttl :
+    {lv}  // Length of v is a member of {256,128,64,32,16,8,4}
+    (lv >= 2, lv <= 8) =>
+    [2^^lv](Z q) -> [8] -> [2^^lv](Z q)
+fast_nttl v k
+  // Base case. lv==2 so just compute the butterfly and return
+  | lv == 2 => ct_butterfly`{lv,lv-1} v (zeta_expc@k)
+
+  // Recursive case. Butterfly what we have, then recurse on each half,
+  // concatenate the results and return
+  | lv  > 2 => coerceSize ((fast_nttl`{lv-1} s0 (k * 2)) #
+                           (fast_nttl`{lv-1} s1 (k * 2 + 1)))
+                where
+                  t = ct_butterfly`{lv,lv-1} v (zeta_expc@k)
+                  // Split t into two halves s0 and s1
+                  [s0, s1] = split (coerceSize t)
+
+// Top level entry point - start with lv=256, k=1
+fast_ntt : Z_q_256 -> Z_q_256
+fast_ntt v = fast_nttl v 1
+
+// Fast recursive GS-Inverse-NTT
+gs_butterfly :
+    {m, hm}
+    (m >= 2, m <= 8, hm >= 1, hm <= 7, hm == m - 1) =>
+    [2^^m](Z q) -> (Z q) -> [2^^m](Z q)
+gs_butterfly v z = new_v
+  where
+    halflen = 2^^`hm
+    lower, upper : [2^^hm](Z q)
+    lower@x = v@x  + v@(x + halflen)
+    upper@x = z * (v@(x + halflen) - v@x)
+    new_v = coerceSize (lower # upper)
+
+fast_invnttl :
+    {lv}  // Length of v is a member of {256,128,64,32,16,8,4}
+    (lv >= 2, lv <= 8) =>
+    [2^^lv](Z q) -> [8] -> [2^^lv](Z q)
+
+fast_invnttl v k
+  // Base case. lv==2 so just compute the butterfly and return
+  | lv == 2 => gs_butterfly`{lv,lv-1} v (zeta_expc@k)
+
+  // Recursive case. Recurse on each half,
+  // concatenate the results, butterfly that, and return
+  | lv  > 2 => gs_butterfly`{lv,lv-1} t (zeta_expc@k)
+                where
+                  // Split t into two halves s0 and s1
+                  [s0, s1] = split (coerceSize v)
+                  t = coerceSize ((fast_invnttl`{lv-1} s0 (k * 2 + 1)) #
+                                  (fast_invnttl`{lv-1} s1 (k * 2)))
+
+// Multiply all elements of v by the reciprocal of 128 (modulo q)
+recip_128_modq = (recip 128) : (Z q)
+mul_recip128 : Z_q_256 -> Z_q_256
+mul_recip128 v = [ v@x * recip_128_modq | x <- [0 .. <n] ]
+
+// Top level entry point - start with lv=256, k=1
+fast_invntt : Z_q_256 -> Z_q_256
+fast_invntt v = mul_recip128 (fast_invnttl v 1)
+
+//////////////////////////////////////////////////////////////
+// Properties and proofs of Naive and Fast NTT
+//////////////////////////////////////////////////////////////
+
+// This property demonstrates that NaiveNTT is self-inverting
+// ```
+// :prove NaiveNTT_Inverts
+// ```
+//
+NaiveNTT_Inverts : Z_q_256 -> Bit
+property NaiveNTT_Inverts f =  NaiveNTTInv (NaiveNTT f) == f
+
+// This property demonstrates that NaiveNTTInv is self-inverting
+// ```
+// :prove NaiveNTTInv_Inverts
+// ```
+//
+NaiveNTTInv_Inverts : Z_q_256 -> Bit
+property NaiveNTTInv_Inverts f =  NaiveNTT (NaiveNTTInv f) == f
+
+// This property demonstrates that `fast_ntt` is the inverse of `fast_invntt`.
+// ```
+// :prove fast_ntt_inverts
+// ```
+fast_ntt_inverts    : Z_q_256 -> Bit
+property fast_ntt_inverts    f =  fast_invntt (fast_ntt f)    == f
+
+// This property demonstrates that `fast_invntt` is the inverse of `fast_ntt`.
+// ```
+// :prove fast_invntt_inverts
+// ```
+fast_invntt_inverts : Z_q_256 -> Bit
+property fast_invntt_inverts f =  fast_ntt    (fast_invntt f) == f
+
+// This property demonstrates that `naive_ntt` is equivalent to `fast_ntt`.
+// ```
+// :prove naive_fast_ntt_equiv
+// ```
+naive_fast_ntt_equiv : Z_q_256 -> Bit
+property naive_fast_ntt_equiv f =  NaiveNTT f == fast_ntt f
+
+// This property demonstrates that `naive_invntt` is equivalent to `fast_invntt`.
+// ```
+// :prove naive_fast_invntt_equiv
+// ```
+naive_fast_invntt_equiv : Z_q_256 -> Bit
+property naive_fast_invntt_equiv f =  NaiveNTTInv f == fast_invntt f
+
+//////////////////////////////////////////////////////////////
+// NTT "dispatcher"
+//
+// Here, we can choose to call either the naive or fast NTT
+//////////////////////////////////////////////////////////////
+
 NTT' : Z_q_256 -> Z_q_256
-NTT' f = ParametricNTT f zeta
+// fast
+NTT' f = fast_ntt f
+// slow
+//NTT' f = NaiveNTT f
 
 NTTInv' : Z_q_256 -> Z_q_256
-NTTInv' f = [term*(recip 128) | term <- ParametricNTTInv f (recip zeta)]
+// fast
+NTTInv' f = fast_invntt f
+// slow
+//NTTInv' f = NaiveNTTInv f
 
-CorrectnessNTT : Z_q_256 -> Bit
-property CorrectnessNTT f =  NTTInv' (NTT' f) == f
-
-
+//////////////////////////////////////////////////////////////
+// Polynomial multiplication in the NTT domain
+//////////////////////////////////////////////////////////////
 
 BaseCaseMultiply : [2] (Z q) -> [2] (Z q) -> (Z q) -> [2] (Z q)
 BaseCaseMultiply a b root = [r0, r1]
@@ -178,7 +352,7 @@ dotMatMat matrix1 matrix2 = transpose [dotMatVec matrix1 vector | vector <- m']
 
 
 // Since Cryptol does not natively support while loops, we approach this
-// potentially infinite loop with recursion. We define SampleNTTInf that 
+// potentially infinite loop with recursion. We define SampleNTTInf that
 // converts an infinite sequence of bytes to an infinite sequence of
 // elements in Z q. We then pick the first n elements for the result.
 
@@ -187,7 +361,7 @@ SampleNTT b = take elements
     where elements = SampleNTTInf b
 
 // SampleNTTInf implements a filter. It scans the input 3 by 3, calculates
-// the elements d1 and d2 and finally returns the elements that satisfy 
+// the elements d1 and d2 and finally returns the elements that satisfy
 // the conditions together with the result of itself when applied to the
 // tail.
 
@@ -320,8 +494,8 @@ K_PKE_Decrypt(sk, c) = m where
   m = EncodeBytes'`{1}(Compress'`{1}(w))
 
 // Kyber is correct with probability 1-delta and not 1. As a result,
-// running :prove Correctness will not succeed since there is a 
-// fraction delta of seeds d,r that do not work. Therefore, we can 
+// running :prove Correctness will not succeed since there is a
+// fraction delta of seeds d,r that do not work. Therefore, we can
 // only run :check Correctness. Cryptol does not currently support counting.
 
 CorrectnessPKE : ([32]Byte, [32]Byte, [32]Byte) -> Bit
@@ -373,8 +547,6 @@ property CorrectnessKEM(z, d, m) = (K == K') where
 
 
 parameter
-  type q : #
-  type constraint (prime q, fin q, lg2 q > 10)
   type k : #
   type constraint (width k > 0, width 2*k <= 8)
   type eta_1 : #
@@ -382,9 +554,10 @@ parameter
   type eta_2 : #
   type constraint (fin eta_2, eta_2 > 0)
   type d_u : #
-  type constraint (fin d_u, d_u < lg2 q, d_u > 0)
+  // both d_u and d_v must be less than lg2 q = 12
+  type constraint (fin d_u, d_u < 12, d_u > 0)
   type d_v : #
-  type constraint (fin d_v, d_v < lg2 q, d_v > 0)
+  type constraint (fin d_v, d_v < 12, d_v > 0)
 
 
 
@@ -403,5 +576,3 @@ import Primitive::Keyless::Hash::SHAKE::SHAKE256
 PRF(s,b) = map reverse (take (groupBy`{8} (shake256(fromBytes(s)# reverse b))))
 
 KDF input = groupBy`{8}(shake256 (fromBytes(input)))
-
-

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -166,6 +166,16 @@ zeta_expc = [ 1, 1729, 2580, 3289, 2642, 630, 1897, 848,
               1722, 1212, 1874, 1029, 2110, 2935, 885, 2154 ]
 
 // Fast recursive CT-NTT
+//
+// The "coerceSize" calls in this code are required to satisfy
+// Cryptol's type constraint solver that this code really
+// is type-correct by effectively changing a static type-check
+// into a dynamic one.
+//
+// As the static type constraint prover improves, this
+// might become unncessesary.
+//
+// See https://github.com/GaloisInc/cryptol/issues/1489 for more details.
 ct_butterfly :
     {m, hm}
     (m >= 2, m <= 8, hm >= 1, hm <= 7, hm == m - 1) =>

--- a/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
+++ b/Primitive/Asymmetric/Cipher/ML-KEM/specification.cry
@@ -210,6 +210,16 @@ fast_ntt : Z_q_256 -> Z_q_256
 fast_ntt v = fast_nttl v 1
 
 // Fast recursive GS-Inverse-NTT
+//
+// The "coerceSize" calls in this code are required to satisfy
+// Cryptol's type constraint solver that this code really
+// is type-correct by effectively changing a static type-check
+// into a dynamic one.
+//
+// As the static type constraint prover improves, this
+// might become unncessesary.
+//
+// See https://github.com/GaloisInc/cryptol/issues/1489 for more details.
 gs_butterfly :
     {m, hm}
     (m >= 2, m <= 8, hm >= 1, hm <= 7, hm == m - 1) =>

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -5,8 +5,8 @@
 # @author Marcella Hastings <marcella@galois.com>
 #
 
-COPYRIGHT="@copyright Galois"
-AUTHOR="@author .*@galois.com>"
+COPYRIGHT="@copyright"
+AUTHOR="@author"
 
 # Filters the set of changed files to only those we want copyright
 # notices on -- files that likely have cryptol code in them.


### PR DESCRIPTION
This PR adds "fast" O(N log N) NTT and Inverse NTT functions for ML-KEM.

Note
1. I moved the "coerceSize" function from Common:ntt to Common::utils so it could be re-used in ML-KEM
2. With the new code, KATs pass OK.
3. Time to run ONE KAT with the old code (on am M1 MacBook Pro) is 38s. With new code, it's 22.5s.
4. A single run of NTTInv(NTT f) with the old code takes 5s. With new code it's 140ms - about 36 times faster.

