### PR TITLE
Add twin multiplication for prime field curves

### DIFF
--- a/Common/EC/PrimeField/PFEC.cry
+++ b/Common/EC/PrimeField/PFEC.cry
@@ -1,46 +1,46 @@
 /*
- NIST-standardized Prime Field Elliptic Curves in short-Weierstrass form.
+NIST-standardized Prime Field Elliptic Curves in short-Weierstrass form.
 
- This contains an implementation of elliptic curve operations for curves
- in short-Weierstrass form, defined over the finite field GF(P), where P
- is an odd prime power (short-Weierstrass form can also be used over the
- binary field GF(2^m), but curves of this form were deprecated in
- [SP-800-186] Section 3.3 and are not supported by this implementation).
+This contains an implementation of elliptic curve operations for curves
+in short-Weierstrass form, defined over the finite field GF(P), where P
+is an odd prime power (short-Weierstrass form can also be used over the
+binary field GF(2^m), but curves of this form were deprecated in
+[SP-800-186] Section 3.3 and are not supported by this implementation).
 
- This implementation has several restrictions that tie it specifically to
- the NIST-standardized curves:
- - it fixes the curve parameter `a = -3`;
- - it fixes the cofactor `h = 1`;
- - it requires that the finite field `GF(P)` is over a prime `P` (not a power).
+This implementation has several restrictions that tie it specifically to
+the NIST-standardized curves:
+- it fixes the curve parameter `a = -3`;
+- it fixes the cofactor `h = 1`;
+- it requires that the finite field `GF(P)` is over a prime `P` (not a power).
 
- This implementation draws from several sources:
- - The NIST recommendation for elliptic curves defines allowable domain
-   parameters and the group operation (`affine_add`) [SP-800-186].
- - The digital signature standard includes some elliptic curve operations
-   needed to implement ECDSA [FIPS-186-5].
- - Additional routines for elliptic curves are defined in [MATH-2008].
- - The SEC1 standard consolidates many of the other resources cited herein.
-   In some cases, we refer to both the original source and [SEC1-v2].
+This implementation draws from several sources:
+- The NIST recommendation for elliptic curves defines allowable domain
+  parameters and the group operation (`affine_add`) [SP-800-186].
+- The digital signature standard includes some elliptic curve operations
+  needed to implement ECDSA [FIPS-186-5].
+- Additional routines for elliptic curves are defined in [MATH-2008].
+- The SEC1 standard consolidates many of the other resources cited herein.
+  In some cases, we refer to both the original source and [SEC1-v2].
 
- References
- [FIPS-186-5]: National Institute of Standards and Technology. Digital
-   Signature Standard (DSS). (Department of Commerce, Washington, D.C.),
-   Federal Information Processing Standards Publication (FIPS) NIST FIPS 186-5.
-   February 2023.
-   @see https://doi.org/10.6028/NIST.FIPS.186-5
- [MATH-2008]: Mathematical routines for the NIST prime elliptic curves.
+References
+[FIPS-186-5]: National Institute of Standards and Technology. Digital
+    Signature Standard (DSS). (Department of Commerce, Washington, D.C.),
+    Federal Information Processing Standards Publication (FIPS) NIST FIPS 186-5.
+    February 2023.
+    @see https://doi.org/10.6028/NIST.FIPS.186-5
+[MATH-2008]: Mathematical routines for the NIST prime elliptic curves.
     March 2008.
     @see https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=e1b05e600bfcdeecf8555bc9948483c5fbbdd478
- [SP-800-186]: Lily Chen, Dustin Moody, Karen Randall, Andrew Regenscheid,
+[SP-800-186]: Lily Chen, Dustin Moody, Karen Randall, Andrew Regenscheid,
     Angela Robinson. Recommendations for Discrete Logarithm-based Cryptography:
     Elliptic Curve Domain Parameters. (National Institute of Standards and
     Technology, Gaithersburg, MD), NIST Special Publication (SP) NIST SP
     800-186. February 2023.
     @see https://doi.org/10.6028/NIST.SP.800-186
-  [SEC1-v2]: Daniel R. L. Brown. SEC 1: Elliptic Curve Cryptography, Version
+ [SEC1-v2]: Daniel R. L. Brown. SEC 1: Elliptic Curve Cryptography, Version
     2.0. Standards for Efficient Cryptography Group. May 2009.
     @see http://www.secg.org/sec1-v2.pdf
-  [SEC2-v2]: Daniel R. L. Brown. SEC 2: Recommened Elliptic Curve Domain
+ [SEC2-v2]: Daniel R. L. Brown. SEC 2: Recommened Elliptic Curve Domain
     Parameters, Version 2.0. Standards for Efficient Cryptography Group. Jan
     2010.
     @see https://www.secg.org/sec2-v2.pdf
@@ -95,7 +95,7 @@ parameter
  *
  * This makes the private functor parameter publicly available.
  */
- type n = n'
+type n = n'
 
 /**
  * Coefficient that defines the curve.
@@ -139,12 +139,12 @@ enum Point = Infinity | Affine (Z P) (Z P)
  */
 affineEq : Point -> Point -> Bool
 affineEq p1 p2 = case p1 of
-  Infinity -> case p2 of
-      Infinity -> True
-      _ -> False
-  Affine x y -> case p2 of
-      Affine x' y' -> (x == x') && (y == y')
-      _ -> False
+    Infinity -> case p2 of
+        Infinity -> True
+        _ -> False
+    Affine x y -> case p2 of
+        Affine x' y' -> (x == x') && (y == y')
+        _ -> False
 
 /**
  * Check that a given point is on the curve -- either it is the point at
@@ -341,8 +341,8 @@ private
         // The point at infinity does not have an affine representation.
         if p.z == 0 then Infinity
         else Affine (lambda ^^2 * p.x) (lambda ^^3 * p.y)
-      where
-        lambda = mp_mod_inv p.z
+        where
+            lambda = mp_mod_inv p.z
 
 
     // The twin affine function depends on the set of four points: two
@@ -400,25 +400,25 @@ private
     ec_double : ProjectivePoint -> ProjectivePoint
     ec_double S =
       if S.z == 0 then InfinityProjective /* 5: r <- (1,1,0) and return */
-      else
-        {x = r18, y = r23, z = r13}
-      where r7  = S.z ^^ 2                /*  7: t4 <- (t3)^2 */
-            r8  = S.x - r7                /*  8: t5 <- t1 - t4 */
-            r9  = S.x + r7                /*  9: t4 <- t1 + t4 */
-            r10 = r9 * r8                 /* 10: t5 <- t4 * t5 */
-            r11 = mul3 r10                /* 11: t4 <- 3 * t5 */
-            r12 = S.z * S.y               /* 12: t3 <- t3 * t2 */
-            r13 = mul2 r12                /* 13: t3 <- 2 * t3 */
-            r14 = S.y ^^ 2                /* 14: t2 <- (t2)^2 */
-            r15 = S.x * r14               /* 15: t5 <- t1 * t2 */
-            r16 = mul4 r15                /* 16: t5 <- 4 * t5 */
-            r17 = r11 ^^ 2                /* 17: t1 <- (t4)^2 */
-            r18 = r17 - (mul2 r16)        /* 18: t1 <- t1 - 2 * t5 */
-            r19 = r14 ^^ 2                /* 19: t2 <- (t2)^2 */
-            r20 = mul8 r19                /* 20: t2 <- 8 * t2 */
-            r21 = r16 - r18               /* 21: t5 <- t5 - t1 */
-            r22 = r11 * r21               /* 22: t5 <- t4 * t5 */
-            r23 = r22 - r20               /* 23: t2 <- t5 - t2 */
+      else {x = r18, y = r23, z = r13}
+      where
+          r7  = S.z ^^ 2                /*  7: t4 <- (t3)^2 */
+          r8  = S.x - r7                /*  8: t5 <- t1 - t4 */
+          r9  = S.x + r7                /*  9: t4 <- t1 + t4 */
+          r10 = r9 * r8                 /* 10: t5 <- t4 * t5 */
+          r11 = mul3 r10                /* 11: t4 <- 3 * t5 */
+          r12 = S.z * S.y               /* 12: t3 <- t3 * t2 */
+          r13 = mul2 r12                /* 13: t3 <- 2 * t3 */
+          r14 = S.y ^^ 2                /* 14: t2 <- (t2)^2 */
+          r15 = S.x * r14               /* 15: t5 <- t1 * t2 */
+          r16 = mul4 r15                /* 16: t5 <- 4 * t5 */
+          r17 = r11 ^^ 2                /* 17: t1 <- (t4)^2 */
+          r18 = r17 - (mul2 r16)        /* 18: t1 <- t1 - 2 * t5 */
+          r19 = r14 ^^ 2                /* 19: t2 <- (t2)^2 */
+          r20 = mul8 r19                /* 20: t2 <- 8 * t2 */
+          r21 = r16 - r18               /* 21: t5 <- t5 - t1 */
+          r22 = r11 * r21               /* 22: t5 <- t4 * t5 */
+          r23 = r22 - r20               /* 23: t2 <- t5 - t2 */
 
     /**
      * Addition of two elliptic curve points.
@@ -430,14 +430,16 @@ private
      */
     ec_add : ProjectivePoint -> ProjectivePoint -> ProjectivePoint
     ec_add S T =
-      if r13 == 0 then
-        if r14 == 0 then Zero       /* 17: r <- (0,0,0) and return */
-        else InfinityProjective     /* 19: r <- (1,1,0) and return */
-      else
-        {x = r32, y = r37, z = r27} /* 38: Rx <- t1; Ry <- t2, Rz <- t3 */
-      where (t1, t2, t3, t4, t5, t6) = if T.z == 1
-              then (S.x, S.y, S.z, T.x, T.y, T.z) /* 1: we set t6 = 1 to make L25 work */
-              else (r5, r7, S.z, T.x, T.y, r3)
+        if r13 == 0 then
+            if r14 == 0 then Zero       /* 17: r <- (0,0,0) and return */
+            else InfinityProjective     /* 19: r <- (1,1,0) and return */
+        else
+            {x = r32, y = r37, z = r27} /* 38: Rx <- t1; Ry <- t2, Rz <- t3 */
+        where
+            (t1, t2, t3, t4, t5, t6) = if T.z == 1 then
+                // 1: set t6 = 1 to make L25 work
+                (S.x, S.y, S.z, T.x, T.y, T.z)
+                else (r5, r7, S.z, T.x, T.y, r3)
 
             r3 = T.z                /* 3: t6 <- T_z */
             r4 = r3 ^^ 2            /* 4: t7 <- t6^2 */
@@ -456,7 +458,8 @@ private
             r23 = mul2 t2 - r14     /* 23: t2 <- 2*t2 - t5 */
 
             r25 = t3 * t6           /* 25: t3 <- t3 * t6 if Tz =/= 1.
-                                       If T.z == 1, then t6 == 1 and this is a no-op */
+                                       If T.z == 1, then t6 == 1 and this is a
+                                       no-op */
 
             r27 = r25 * r13          /* 27: t3 <- t3 * t4 */
             r28 = r13 ^^ 2           /* 28: t7 <- (t4)^2 */
@@ -480,11 +483,11 @@ private
      */
     ec_full_add : ProjectivePoint -> ProjectivePoint -> ProjectivePoint
     ec_full_add S T =
-      if S.z == 0 then T
-       | T.z == 0 then S
-       | R == {x = 0, y = 0, z = 0} then ec_double S
-       else R
-      where R = ec_add S T
+        if S.z == 0 then T
+        | T.z == 0 then S
+        | R == {x = 0, y = 0, z = 0} then ec_double S
+        else R
+        where R = ec_add S T
 
     /**
      * Checked subtraction of two elliptic curve points.
@@ -509,26 +512,27 @@ private
      */
     ec_mult : Z P -> ProjectivePoint -> ProjectivePoint
     ec_mult d S =
-      if d == 0 then to_projective Infinity
-       | d == 1 then S
-       | S.z == 0 then to_projective Infinity
-      else Rs ! 1 /* the iteration stops at 1, not 0 */
-      where
-        S' = if S.z != 1 then to_projective (to_affine S) else S
-        // Get bits of `d` and `3d`. The width of `ks` is set to be large
-        // enough to hold the full width of `hs`.
-        ks = ZtoBV d : [width P + 2]
-        hs = 3 * ks
+        if d == 0 then to_projective Infinity
+        | d == 1 then S
+        | S.z == 0 then to_projective Infinity
+        else Rs ! 1 /* the iteration stops at 1, not 0 */
+        where
+            S' = if S.z != 1 then to_projective (to_affine S) else S
+            // Get bits of `d` and `3d`. The width of `ks` is set to be large
+            // enough to hold the full width of `hs`.
+            ks = ZtoBV d : [width P + 2]
+            hs = 3 * ks
 
-        // The specified routine initializes R = S and skips the first high-bit
-        // of `hs`, assuming that it's 1. Since we're a little floppy with our
-        // bitwise conversion, we'll start at 0 and iterate over all the bits.
-        Rs = [ InfinityProjective ] #
-             [ if hi && ~ki then ec_full_add doubleR S
-                | ~hi && ki then ec_full_sub doubleR S
-                else doubleR
-               where doubleR = ec_double Ri
-             | ki <- ks | hi <- hs | Ri <- Rs ]
+            // The specified routine initializes R = S and skips the first
+            // high-bit of `hs`, assuming that it's 1. Since we're a little
+            // floppy with our bitwise conversion, we'll start at 0 and
+            // iterate over all the bits.
+            Rs = [ InfinityProjective ] #
+                [ if hi && ~ki then ec_full_add doubleR S
+                  | ~hi && ki then ec_full_sub doubleR S
+                  else doubleR
+                  where doubleR = ec_double Ri
+                | ki <- ks | hi <- hs | Ri <- Rs ]
 
     /**
      * Addition of two elliptic curve points on a prime-field curve with
@@ -571,9 +575,9 @@ private
      */
     validPointFromK : Z n' -> Point
     validPointFromK k = to_affine (ec_mult _k (to_projective G))
-      where
-        _k : Z P
-        _k = fromInteger (fromZ k)
+        where
+            _k : Z P
+            _k = fromInteger (fromZ k)
 
     /**
      * Proof that the affine and projective versions of addition are equivalent.
@@ -585,10 +589,11 @@ private
      */
     addsAreEquivalent : Z n' -> Z n' -> Bool
     property addsAreEquivalent k1 k2 =
-        affineEq (affine_add p1 p2) (to_affine (ec_full_add (to_projective p1) (to_projective p2)))
+        affineEq (affine_add p1 p2) (to_affine full_sum)
         where
             p1 = validPointFromK k1
             p2 = validPointFromK k2
+            full_sum = ec_full_add (to_projective p1) (to_projective p2)
 
     /**
      * Proof that both addition properties work correctly for the point at infinity.
@@ -598,7 +603,8 @@ private
      * ```
      */
     addsBehaveCorrectlyAtInfinity : Z n' -> Bool
-    property addsBehaveCorrectlyAtInfinity k = oo && ok && ko && oo' && ok' && ko'
+    property addsBehaveCorrectlyAtInfinity k =
+        oo && ok && ko && oo' && ok' && ko'
         where
             // Compute infinity identies in affine form.
             point = validPointFromK k
@@ -608,7 +614,8 @@ private
 
             // Compute infinity identies in projective form.
             point' = to_projective point
-            oo' = InfinityProjective == ec_full_add InfinityProjective InfinityProjective
+            oo' = InfinityProjective ==
+                ec_full_add InfinityProjective InfinityProjective
             ok' = point' == ec_full_add InfinityProjective point'
             ko' = point' == ec_full_add point' InfinityProjective
 
@@ -617,8 +624,8 @@ private
      * Twin multiplication computes `[d0]S + [d1]T`.
      * [MATH-2008] Routine 2.2.12.
      *
-     * [MATH-2008] Section 2.2, Note 8 describes an optimization that can be made by
-     * converting the input points between affine and projective
+     * [MATH-2008] Section 2.2, Note 8 describes an optimization that can be
+     * made by converting the input points between affine and projective
      * representations. That is not included here.
      */
     ec_twin_mult : Z P -> ProjectivePoint -> Z P -> ProjectivePoint -> ProjectivePoint
@@ -629,38 +636,43 @@ private
             // [MATH-2008] Section 2.2, Note 8 describes an optimization to
             // speed up the arithmetic in L19-26 by normalizing (convert to
             // affine and then back to projective) the points.
-            {A=S', B=T', C=SpT', D=SmT'} = twin_normalize {A=S, B=T, C=SpT, D=SmT}
+            { A=S', B=T', C=SpT', D=SmT' } =
+                twin_normalize { A=S, B=T, C=SpT, D=SmT }
             e0s = ZtoBV d0 : [max 4 (width P)]         /* Line 3 */
             e1s = ZtoBV d1 : [max 4 (width P)]         /* Line 4 */
             c   = [[False, False] # take e0s,          /* Line 5 */
                    [False, False] # take e1s] : [2][6]
             states = [(InfinityProjective, c)] #       /* Line 6 */
                 [ (Rk', [c0', c1'])
-                  where
-                     // Lines 8-13.
-                     // `tail ci` uses Cryptol's built-in bit vector representation
-                     // to reconstruct `hi` as in L9.
-                     h0 = if c0@0 then 31 - tail c0 else tail c0
-                     h1 = if c1@0 then 31 - tail c1 else tail c1
-                     // Lines 14-16.
-                     u0 = if h0 < (F h1) then 0 else if c0@0 then -1 else 1 : [2]
-                     u1 = if h1 < (F h0) then 0 else if c1@0 then -1 else 1 : [2]
-                     // Line 17.
-                     // The absolute value function on bits is computed as (u_i != 0).
-                     c0' = [(u0!=0) ^ c0@1] # drop c0 # [e0k]
-                     c1' = [(u1!=0) ^ c1@1] # drop c1 # [e1k]
-                     // Line 18.
-                     RkDouble = ec_double Rk
-                     // Lines 19-26.
-                     Rk' = if (u0 == -1) && (u1 == -1) then ec_full_sub RkDouble SpT'
-                            | (u0 == -1) && (u1 ==  0) then ec_full_sub RkDouble S'
-                            | (u0 == -1) && (u1 ==  1) then ec_full_sub RkDouble SmT'
-                            | (u0 ==  0) && (u1 == -1) then ec_full_sub RkDouble T'
-                            | (u0 ==  0) && (u1 ==  1) then ec_full_add RkDouble T'
-                            | (u0 ==  1) && (u1 == -1) then ec_full_add RkDouble SmT'
-                            | (u0 ==  1) && (u1 ==  0) then ec_full_add RkDouble S'
-                            | (u0 ==  1) && (u1 ==  1) then ec_full_add RkDouble SpT'
-                            else RkDouble
+                    where
+                    // Lines 8-13.
+                    // `tail ci` uses Cryptol's built-in bit vector
+                    // representation to reconstruct `hi` as in L9.
+                    h0 = if c0@0 then 31 - tail c0 else tail c0
+                    h1 = if c1@0 then 31 - tail c1 else tail c1
+                    // Lines 14-16.
+                    u0 = if h0 < (F h1) then 0 else if c0@0 then -1 else 1 : [2]
+                    u1 = if h1 < (F h0) then 0 else if c1@0 then -1 else 1 : [2]
+                    // Line 17.
+                    // The absolute value on bits is computed as (u_i != 0).
+                    c0' = [(u0!=0) ^ c0@1] # drop c0 # [e0k]
+                    c1' = [(u1!=0) ^ c1@1] # drop c1 # [e1k]
+                    // Line 18.
+                    RkDouble = ec_double Rk
+                    // Lines 19-26.
+                    Rk' = if (u0 == -1) && (u1 == -1) then
+                            ec_full_sub RkDouble SpT'
+                        | (u0 == -1) && (u1 ==  0) then ec_full_sub RkDouble S'
+                        | (u0 == -1) && (u1 ==  1) then
+                            ec_full_sub RkDouble SmT'
+                        | (u0 ==  0) && (u1 == -1) then ec_full_sub RkDouble T'
+                        | (u0 ==  0) && (u1 ==  1) then ec_full_add RkDouble T'
+                        | (u0 ==  1) && (u1 == -1) then
+                            ec_full_add RkDouble SmT'
+                        | (u0 ==  1) && (u1 ==  0) then ec_full_add RkDouble S'
+                        | (u0 ==  1) && (u1 ==  1) then
+                            ec_full_add RkDouble SpT'
+                        else RkDouble
                 | (Rk, [c0, c1]) <- states
                 // Line 7: Iterate through the eis, after dropping the four
                 // bits we already used to initialize `c` and padding with 0.
@@ -671,10 +683,10 @@ private
             // [MATH-2008] Routine 2.2.11.
             F : [5] -> [5]
             F t = if (18 <= t) && (t < 22) then 9
-                   | (14 <= t) && (t < 18) then 10
-                   | (22 <= t) && (t < 24) then 11
-                   | (4 <= t)  && (t < 12) then 14
-                   else 12
+                | (14 <= t) && (t < 18) then 10
+                | (22 <= t) && (t < 24) then 11
+                | (4 <= t)  && (t < 12) then 14
+                else 12
 
     /**
      * Checks that twin multiplication works as expected. Note that a given

--- a/Common/EC/PrimeField/PFEC.cry
+++ b/Common/EC/PrimeField/PFEC.cry
@@ -392,6 +392,36 @@ private
 
 
     /**
+     * This checks that the normalization function doesn't break on normalized
+     * points. The actual, more interesting check would be to generate random
+     * projective points (in non-normal representation, e.g. where the z coord
+     * is not 1) on the curve and run those through `twin_normalize` but there
+     * is not an obvious efficient way to sample such points.
+     *
+     * ```repl
+     * :set tests=25
+     * :check normalizeWorksOnNormalPoints
+     * ```
+     */
+    property normalizeWorksOnNormalPoints k1 k2 k3 k4 =
+        all_are_normal && all_match
+        where
+            p1 = to_projective (validPointFromK k1)
+            p2 = to_projective (validPointFromK k2)
+            p3 = to_projective (validPointFromK k3)
+            p4 = to_projective (validPointFromK k4)
+
+            input = {A=p1, B=p2, C=p3, D=p4}
+            out = twin_normalize input
+
+            all_are_normal = (out.A.z == 1) && (out.B.z == 1)
+                && (out.C.z == 1) && (out.D.z == 1)
+            all_match = (out.A == p1) && (out.B == p2)
+                && (out.C == p3) && (out.D == p4)
+
+
+
+    /**
      * Double an elliptic curve point.
      * [MATH-2008] Routine 2.2.6.
      *

--- a/Common/EC/PrimeField/PFEC.cry
+++ b/Common/EC/PrimeField/PFEC.cry
@@ -343,6 +343,53 @@ private
       where
         lambda = mp_mod_inv p.z
 
+
+    // The twin affine function depends on the set of four points: two
+    // arbitrary points S and T, their sum SpT, and their difference SmT.
+    type TwinPoints = {
+        A: ProjectivePoint,
+        B: ProjectivePoint,
+        C: ProjectivePoint,
+        D: ProjectivePoint
+    }
+    /**
+     * Optimized routine to affinify and projectify four points at once
+     * (or do nothing, if any of the points are the point at infinity).
+     *
+     * This optimization is designed for use in `ec_twin_mult` and should not
+     * be used in other settings without checking that its behavior is suitable.
+     * [MATH-2008] Section 2.2, Note 8.
+     */
+    twin_normalize: TwinPoints -> TwinPoints
+    twin_normalize { A=A, B=B, C=C, D=D } =
+        // We can't compute twin normalization on the point at infinity
+        // because it doesn't have an inverse. Instead, skip the normalization
+        // step (the algorithm will still work!)
+        if (A.z == 0) || (B.z == 0) || (C.z == 0) || (D.z == 0) then
+            { A=A, B=B, C=C, D=D }
+        else {
+            A = normalize_from_inv A a_inv,
+            B = normalize_from_inv B b_inv,
+            C = normalize_from_inv C c_inv,
+            D = normalize_from_inv D d_inv
+        }
+        where
+            ab = A.z * B.z
+            cd = C.z * D.z
+            abc = ab * C.z
+            abd = ab * D.z
+            acd = A.z * cd
+            bcd = B.z * cd
+            abcd = ab * cd
+            e = recip abcd
+            a_inv = e * bcd
+            b_inv = e * acd
+            c_inv = e * abd
+            d_inv = e * abc
+            normalize_from_inv p inv =
+                to_projective (Affine (inv ^^2 * p.x) (inv ^^3 * p.y))
+
+
     /**
      * Double an elliptic curve point.
      * [MATH-2008] Routine 2.2.6.
@@ -578,6 +625,10 @@ private
         where
             SpT = ec_full_add S T                      /* Line 1 */
             SmT = ec_full_sub S T                      /* Line 2 */
+            // [MATH-2008] Section 2.2, Note 8 describes an optimization to
+            // speed up the arithmetic in L19-26 by normalizing (convert to
+            // affine and then back to projective) the points.
+            {A=S', B=T', C=SpT', D=SmT'} = twin_normalize {A=S, B=T, C=SpT, D=SmT}
             e0s = ZtoBV d0 : [max 4 (width P)]         /* Line 3 */
             e1s = ZtoBV d1 : [max 4 (width P)]         /* Line 4 */
             c   = [[False, False] # take e0s,          /* Line 5 */
@@ -600,14 +651,14 @@ private
                      // Line 18.
                      RkDouble = ec_double Rk
                      // Lines 19-26.
-                     Rk' = if (u0 == -1) && (u1 == -1) then ec_full_sub RkDouble SpT
-                            | (u0 == -1) && (u1 ==  0) then ec_full_sub RkDouble S
-                            | (u0 == -1) && (u1 ==  1) then ec_full_sub RkDouble SmT
-                            | (u0 ==  0) && (u1 == -1) then ec_full_sub RkDouble T
-                            | (u0 ==  0) && (u1 ==  1) then ec_full_add RkDouble T
-                            | (u0 ==  1) && (u1 == -1) then ec_full_add RkDouble SmT
-                            | (u0 ==  1) && (u1 ==  0) then ec_full_add RkDouble S
-                            | (u0 ==  1) && (u1 ==  1) then ec_full_add RkDouble SpT
+                     Rk' = if (u0 == -1) && (u1 == -1) then ec_full_sub RkDouble SpT'
+                            | (u0 == -1) && (u1 ==  0) then ec_full_sub RkDouble S'
+                            | (u0 == -1) && (u1 ==  1) then ec_full_sub RkDouble SmT'
+                            | (u0 ==  0) && (u1 == -1) then ec_full_sub RkDouble T'
+                            | (u0 ==  0) && (u1 ==  1) then ec_full_add RkDouble T'
+                            | (u0 ==  1) && (u1 == -1) then ec_full_add RkDouble SmT'
+                            | (u0 ==  1) && (u1 ==  0) then ec_full_add RkDouble S'
+                            | (u0 ==  1) && (u1 ==  1) then ec_full_add RkDouble SpT'
                             else RkDouble
                 | (Rk, [c0, c1]) <- states
                 // Line 7: Iterate through the eis, after dropping the four
@@ -624,6 +675,14 @@ private
                    | (4 <= t)  && (t < 12) then 14
                    else 12
 
+    /**
+     * Checks that twin multiplication works as expected. Note that a given
+     * point can have multiple projective representations, so we have to
+     * check equality in the affine representation.
+     * ```repl
+     * :check twin_mult_works
+     * ```
+     */
     property twin_mult_works d0 k0 d1 k1 = affineEq R_plain R_twin
         where
             S = to_projective (validPointFromK k0)

--- a/Common/EC/PrimeField/PFEC.cry
+++ b/Common/EC/PrimeField/PFEC.cry
@@ -297,12 +297,13 @@ property scmul_commutes m m' = affineEq (m ~* (m' ~* G)) (m' ~* (m ~* G))
 
 /**
  * Compute twin multiplication.
- *
- * There's a more efficient routine to implement this functionality, but we
- * haven't implemented it here yet. [MATH-2008] Routine 2.2.12.
  */
 twin_mul : Integer -> Point -> Integer -> Point -> Point
-twin_mul c P d Q = add (c ~* P) (d ~* Q)
+twin_mul c P d Q = to_affine (ec_twin_mult c' P' d' Q')
+    where
+        [c', d'] = [fromInteger   x | x <- [c, d]]
+        [P', Q'] = [to_projective p | p <- [P, Q]]
+
 
 
 /**

--- a/Common/EC/PrimeField/PFEC.cry
+++ b/Common/EC/PrimeField/PFEC.cry
@@ -211,9 +211,9 @@ add p1 p2 = to_affine (ec_full_add (to_projective p1) (to_projective p2))
  * ```
  */
 property addIsClosed k1 k2 = valid_point (add p1 p2)
-  where
-    p1 = validPointFromK k1
-    p2 = validPointFromK k2
+    where
+        p1 = validPointFromK k1
+        p2 = validPointFromK k2
 
 /**
  * Double an elliptic curve point.
@@ -233,8 +233,8 @@ double p = to_affine (ec_double (to_projective p))
  * ```
  */
 property doubleIsClosed k = valid_point (double p)
-  where
-    p = validPointFromK k
+    where
+        p = validPointFromK k
 
 /**
  * Subtract one curve point from another.
@@ -254,9 +254,9 @@ sub p1 p2 = to_affine (ec_full_sub (to_projective p1) (to_projective p2))
  * ```
  */
 property subIsClosed k1 k2 = valid_point (sub p1 p2)
-  where
-    p1 = validPointFromK k1
-    p2 = validPointFromK k2
+    where
+        p1 = validPointFromK k1
+        p2 = validPointFromK k2
 
 /**
  * Scalar multiplication of a curve point.
@@ -447,7 +447,8 @@ private
      */
     ec_full_sub : ProjectivePoint -> ProjectivePoint -> ProjectivePoint
     ec_full_sub S T = R
-      where U = {x = T.x, y = -T.y, z = T.z}
+        where
+            U = {x = T.x, y = -T.y, z = T.z}
             R = ec_full_add S U
 
     /**
@@ -563,3 +564,69 @@ private
             ok' = point' == ec_full_add InfinityProjective point'
             ko' = point' == ec_full_add point' InfinityProjective
 
+
+    /**
+     * Twin multiplication computes `[d0]S + [d1]T`.
+     * [MATH-2008] Routine 2.2.12.
+     *
+     * [MATH-2008] Section 2.2, Note 8 describes an optimization that can be made by
+     * converting the input points between affine and projective
+     * representations. That is not included here.
+     */
+    ec_twin_mult : Z P -> ProjectivePoint -> Z P -> ProjectivePoint -> ProjectivePoint
+    ec_twin_mult d0 S d1 T = (states!0).0
+        where
+            SpT = ec_full_add S T                      /* Line 1 */
+            SmT = ec_full_sub S T                      /* Line 2 */
+            e0s = ZtoBV d0 : [max 4 (width P)]         /* Line 3 */
+            e1s = ZtoBV d1 : [max 4 (width P)]         /* Line 4 */
+            c   = [[False, False] # take e0s,          /* Line 5 */
+                   [False, False] # take e1s] : [2][6]
+            states = [(InfinityProjective, c)] #       /* Line 6 */
+                [ (Rk', [c0', c1'])
+                  where
+                     // Lines 8-13.
+                     // `tail ci` uses Cryptol's built-in bit vector representation
+                     // to reconstruct `hi` as in L9.
+                     h0 = if c0@0 then 31 - tail c0 else tail c0
+                     h1 = if c1@0 then 31 - tail c1 else tail c1
+                     // Lines 14-16.
+                     u0 = if h0 < (F h1) then 0 else if c0@0 then -1 else 1 : [2]
+                     u1 = if h1 < (F h0) then 0 else if c1@0 then -1 else 1 : [2]
+                     // Line 17.
+                     // The absolute value function on bits is computed as (u_i != 0).
+                     c0' = [(u0!=0) ^ c0@1] # drop c0 # [e0k]
+                     c1' = [(u1!=0) ^ c1@1] # drop c1 # [e1k]
+                     // Line 18.
+                     RkDouble = ec_double Rk
+                     // Lines 19-26.
+                     Rk' = if (u0 == -1) && (u1 == -1) then ec_full_sub RkDouble SpT
+                            | (u0 == -1) && (u1 ==  0) then ec_full_sub RkDouble S
+                            | (u0 == -1) && (u1 ==  1) then ec_full_sub RkDouble SmT
+                            | (u0 ==  0) && (u1 == -1) then ec_full_sub RkDouble T
+                            | (u0 ==  0) && (u1 ==  1) then ec_full_add RkDouble T
+                            | (u0 ==  1) && (u1 == -1) then ec_full_add RkDouble SmT
+                            | (u0 ==  1) && (u1 ==  0) then ec_full_add RkDouble S
+                            | (u0 ==  1) && (u1 ==  1) then ec_full_add RkDouble SpT
+                            else RkDouble
+                | (Rk, [c0, c1]) <- states
+                // Line 7: Iterate through the eis, after dropping the four
+                // bits we already used to initialize `c` and padding with 0.
+                | e0k <- drop`{4} e0s # (zero : [5])
+                | e1k <- drop`{4} e1s # (zero : [5]) ]
+
+            // An auxiliary routine.
+            // [MATH-2008] Routine 2.2.11.
+            F : [5] -> [5]
+            F t = if (18 <= t) && (t < 22) then 9
+                   | (14 <= t) && (t < 18) then 10
+                   | (22 <= t) && (t < 24) then 11
+                   | (4 <= t)  && (t < 12) then 14
+                   else 12
+
+    property twin_mult_works d0 k0 d1 k1 = affineEq R_plain R_twin
+        where
+            S = to_projective (validPointFromK k0)
+            T = to_projective (validPointFromK k1)
+            R_plain = to_affine (ec_add (ec_mult d0 S) (ec_mult d1 T))
+            R_twin = to_affine (ec_twin_mult d0 S d1 T)

--- a/Common/EC/Tests/P192.cry
+++ b/Common/EC/Tests/P192.cry
@@ -85,14 +85,15 @@ property scalarMultVectorPasses2 = P192::affineEq (P192::scmul d S') R
         d = toInteger 0xe14f37b3d1374ff8b03f41b9b3fdd2f0ebccf275d660d7f3
         R = P192::Affine (BVtoZ 0x07008ea40b08dbe76432096e80a2494c94982d2d5bcf98e6)
             (BVtoZ 0x76fab681d00b414ea636ba215de26d98c41bd7f2e4d65477)
-/*
-// NB: We haven't implemented the joint-scalar-multiply algorithm yet (aka
-// twin_mult), but when we do we can use this test vector.
-property p192_joint_scalar_multiply_example =
-  p192::joint_scalar_multiply_example R S T d e
-  where d = BVtoZ 0xa78a236d60baec0c5dd41b33a542463a8255391af64c74ee
-        e = BVtoZ 0xc4be3d53ec3089e71e4de8ceab7cce889bc393cd85b972bc
-        R = {x = BVtoZ 0x019f64eed8fa9b72b7dfea82c17c9bfa60ecb9e1778b5bde,
-             y = BVtoZ 0x16590c5fcd8655fa4ced33fb800e2a7e3c61f35d83503644}
-*/
 
+/**
+ * ```repl
+ * :prove twinMultVectorPasses
+ * ```
+ */
+property twinMultVectorPasses =
+  P192::affineEq R (P192::twin_mul d S e T)
+  where d = toInteger 0xa78a236d60baec0c5dd41b33a542463a8255391af64c74ee
+        e = toInteger 0xc4be3d53ec3089e71e4de8ceab7cce889bc393cd85b972bc
+        R = P192::Affine (BVtoZ 0x019f64eed8fa9b72b7dfea82c17c9bfa60ecb9e1778b5bde)
+            (BVtoZ 0x16590c5fcd8655fa4ced33fb800e2a7e3c61f35d83503644)

--- a/Common/EC/Tests/P224.cry
+++ b/Common/EC/Tests/P224.cry
@@ -69,13 +69,14 @@ property scalarMultVectorPasses = P224::affineEq (P224::scmul d S) R
         R = P224::Affine (BVtoZ 0x96a7625e92a8d72bff1113abdb95777e736a14c6fdaacc392702bca4)
              (BVtoZ 0x0f8e5702942a3c5e13cd2fd5801915258b43dfadc70d15dbada3ed10)
 
-/*
-// NB: We haven't implemented the joint-scalar-multiply algorithm yet (aka
-// twin_mult), but when we do we can use this test vector.
-property p224_joint_scalar_multiply_example =
-  p224::joint_scalar_multiply_example R S T d e
-  where d = BVtoZ 0xa78ccc30eaca0fcc8e36b2dd6fbb03df06d37f52711e6363aaf1d73b
-        e = BVtoZ 0x54d549ffc08c96592519d73e71e8e0703fc8177fa88aa77a6ed35736
-        R = {x = BVtoZ 0xdbfe2958c7b2cda1302a67ea3ffd94c918c5b350ab838d52e288c83e,
-             y = BVtoZ 0x2f521b83ac3b0549ff4895abcc7f0c5a861aacb87acbc5b8147bb18b}
-*/
+/**
+ * ```repl
+ * :prove twinMultVectorPasses
+ * ```
+ */
+property twinMultVectorPasses =
+  P224::affineEq R (P224::twin_mul d S e T)
+  where d = toInteger 0xa78ccc30eaca0fcc8e36b2dd6fbb03df06d37f52711e6363aaf1d73b
+        e = toInteger 0x54d549ffc08c96592519d73e71e8e0703fc8177fa88aa77a6ed35736
+        R = P224::Affine (BVtoZ 0xdbfe2958c7b2cda1302a67ea3ffd94c918c5b350ab838d52e288c83e)
+            (BVtoZ 0x2f521b83ac3b0549ff4895abcc7f0c5a861aacb87acbc5b8147bb18b)

--- a/Common/EC/Tests/P256.cry
+++ b/Common/EC/Tests/P256.cry
@@ -68,13 +68,14 @@ property scalarMultVectorPasses = P256::affineEq (P256::scmul d S) R
         R = P256::Affine (BVtoZ 0x51d08d5f2d4278882946d88d83c97d11e62becc3cfc18bedacc89ba34eeca03f)
              (BVtoZ 0x75ee68eb8bf626aa5b673ab51f6e744e06f8fcf8a6c0cf3035beca956a7b41d5)
 
-/*
-// NB: We haven't implemented the joint-scalar-multiply algorithm yet (aka
-// twin_mult), but when we do we can use this test vector.
-property p256_joint_scalar_multiply_example =
-  p256::joint_scalar_multiply_example R S T d e
-  where d = BVtoZ 0xc51e4753afdec1e6b6c6a5b992f43f8dd0c7a8933072708b6522468b2ffb06fd
-        e = BVtoZ 0xd37f628ece72a462f0145cbefe3f0b355ee8332d37acdd83a358016aea029db7
-        R = {x = BVtoZ 0xd867b4679221009234939221b8046245efcf58413daacbeff857b8588341f6b8,
-             y = BVtoZ 0xf2504055c03cede12d22720dad69c745106b6607ec7e50dd35d54bd80f615275}
-*/
+/**
+ * ```repl
+ * :prove twinMultVectorPasses
+ * ```
+ */
+property twinMultVectorPasses =
+  P256::affineEq R (P256::twin_mul d S e T)
+  where d = toInteger 0xc51e4753afdec1e6b6c6a5b992f43f8dd0c7a8933072708b6522468b2ffb06fd
+        e = toInteger 0xd37f628ece72a462f0145cbefe3f0b355ee8332d37acdd83a358016aea029db7
+        R = P256::Affine (BVtoZ 0xd867b4679221009234939221b8046245efcf58413daacbeff857b8588341f6b8)
+            (BVtoZ 0xf2504055c03cede12d22720dad69c745106b6607ec7e50dd35d54bd80f615275)

--- a/Common/EC/Tests/P384.cry
+++ b/Common/EC/Tests/P384.cry
@@ -69,13 +69,14 @@ property scalarMultVectorPasses = P384::affineEq (P384::scmul d S) R
         R = P384::Affine (BVtoZ 0xe4f77e7ffeb7f0958910e3a680d677a477191df166160ff7ef6bb5261f791aa7b45e3e653d151b95dad3d93ca0290ef2)
              (BVtoZ 0xac7dee41d8c5f4a7d5836960a773cfc1376289d3373f8cf7417b0c6207ac32e913856612fc9ff2e357eb2ee05cf9667f)
 
-/*
-// NB: We haven't implemented the joint-scalar-multiply algorithm yet (aka
-// twin_mult), but when we do we can use this test vector.
-property p384_joint_scalar_multiply_example =
-  p384::joint_scalar_multiply_example R S T d e
-  where d = BVtoZ 0xa4ebcae5a665983493ab3e626085a24c104311a761b5a8fdac052ed1f111a5c44f76f45659d2d111a61b5fdd97583480
-        e = BVtoZ 0xafcf88119a3a76c87acbd6008e1349b29f4ba9aa0e12ce89bcfcae2180b38d81ab8cf15095301a182afbc6893e75385d
-        R = {x = BVtoZ 0x917ea28bcd641741ae5d18c2f1bd917ba68d34f0f0577387dc81260462aea60e2417b8bdc5d954fc729d211db23a02dc,
-             y = BVtoZ 0x1a29f7ce6d074654d77b40888c73e92546c8f16a5ff6bcbd307f758d4aee684beff26f6742f597e2585c86da908f7186}
-*/
+/**
+ * ```repl
+ * :prove twinMultVectorPasses
+ * ```
+ */
+property twinMultVectorPasses =
+  P384::affineEq R (P384::twin_mul d S e T)
+  where d = toInteger 0xa4ebcae5a665983493ab3e626085a24c104311a761b5a8fdac052ed1f111a5c44f76f45659d2d111a61b5fdd97583480
+        e = toInteger 0xafcf88119a3a76c87acbd6008e1349b29f4ba9aa0e12ce89bcfcae2180b38d81ab8cf15095301a182afbc6893e75385d
+        R = P384::Affine (BVtoZ 0x917ea28bcd641741ae5d18c2f1bd917ba68d34f0f0577387dc81260462aea60e2417b8bdc5d954fc729d211db23a02dc)
+            (BVtoZ 0x1a29f7ce6d074654d77b40888c73e92546c8f16a5ff6bcbd307f758d4aee684beff26f6742f597e2585c86da908f7186)

--- a/Common/EC/Tests/P521.cry
+++ b/Common/EC/Tests/P521.cry
@@ -69,13 +69,14 @@ property scalarMultVectorPasses = P521::affineEq (P521::scmul d S) R
         R = P521::Affine (BVtoZ 0x00000091b15d09d0ca0353f8f96b93cdb13497b0a4bb582ae9ebefa35eee61bf7b7d041b8ec34c6c00c0c0671c4ae063318fb75be87af4fe859608c95f0ab4774f8c95bb)
              (BVtoZ 0x00000130f8f8b5e1abb4dd94f6baaf654a2d5810411e77b7423965e0c7fd79ec1ae563c207bd255ee9828eb7a03fed565240d2cc80ddd2cecbb2eb50f0951f75ad87977f)
 
-/*
-// NB: We haven't implemented the joint-scalar-multiply algorithm yet (aka
-// twin_mult), but when we do we can use this test vector.
-property p521_joint_scalar_multiply_example =
-  p521::joint_scalar_multiply_example R S T d e
-  where d = BVtoZ 0x000001eb7f81785c9629f136a7e8f8c674957109735554111a2a866fa5a166699419bfa9936c78b62653964df0d6da940a695c7294d41b2d6600de6dfcf0edcfc89fdcb1
-        e = BVtoZ 0x00000137e6b73d38f153c3a7575615812608f2bab3229c92e21c0d1c83cfad9261dbb17bb77a63682000031b9122c2f0cdab2af72314be95254de4291a8f85f7c70412e3
-        R = {x = BVtoZ 0x0000009d3802642b3bea152beb9e05fba247790f7fc168072d363340133402f2585588dc1385d40ebcb8552f8db02b23d687cae46185b27528adb1bf9729716e4eba653d,
-             y = BVtoZ 0x0000000fe44344e79da6f49d87c1063744e5957d9ac0a505bafa8281c9ce9ff25ad53f8da084a2deb0923e46501de5797850c61b229023dd9cf7fc7f04cd35ebb026d89d}
-*/
+/**
+ * ```repl
+ * :prove twinMultVectorPasses
+ * ```
+ */
+property twinMultVectorPasses =
+  P521::affineEq R (P521::twin_mul d S e T)
+  where d = toInteger 0x000001eb7f81785c9629f136a7e8f8c674957109735554111a2a866fa5a166699419bfa9936c78b62653964df0d6da940a695c7294d41b2d6600de6dfcf0edcfc89fdcb1
+        e = toInteger 0x00000137e6b73d38f153c3a7575615812608f2bab3229c92e21c0d1c83cfad9261dbb17bb77a63682000031b9122c2f0cdab2af72314be95254de4291a8f85f7c70412e3
+        R = P521::Affine (BVtoZ 0x0000009d3802642b3bea152beb9e05fba247790f7fc168072d363340133402f2585588dc1385d40ebcb8552f8db02b23d687cae46185b27528adb1bf9729716e4eba653d)
+            (BVtoZ 0x0000000fe44344e79da6f49d87c1063744e5957d9ac0a505bafa8281c9ce9ff25ad53f8da084a2deb0923e46501de5797850c61b229023dd9cf7fc7f04cd35ebb026d89d)


### PR DESCRIPTION
Closes #103

This adds an efficient utility function for prime field elliptic curves that's used in decryption for ECDSA. Twin multiplication is the operation 
$` f(x, S, y, T) = [x]S + [y]T `$

I am open to debate about whether this is worth including in this repo. It has two parts: twin multiplication itself and an optimized method to normalize four points at once. Neither of these are standardized by NIST or any other body, as far as I can tell (they're included in the "optimized routines for NIST curves" doc). Neither of them are necessary for correct functionality -- we can always do the naive thing of two scalar multiplications and an addition. It's also not intuitive at all (to my eyes, at least).