### PR TITLE
Add preliminaries for SHA2

### DIFF
--- a/Primitive/Asymmetric/Signature/ECDSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Specification.cry
@@ -54,7 +54,7 @@ import Primitive::Asymmetric::Signature::ECDSA::UnconstrainedSpec
  *   for any technical reason. This is intended to be a temporary state,
  *   blocked on the creation of such an interface.
  */
-import Primitive::Keyless::Hash::SHA2::SHA256 as Hash
+import Primitive::Keyless::Hash::SHA2Imperative::SHA256 as Hash
 
 /**
  * The standard specifies four ranges for the bit length of `n` (the order of

--- a/Primitive/Asymmetric/Signature/ECDSA/UnconstrainedSpec.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/UnconstrainedSpec.cry
@@ -50,7 +50,7 @@ import interface Common::EC::ECInterface as EC
  * This implementation currently fixes the hash function to SHA256, as
  * specified in [FIPS-180-4].
  */
-import Primitive::Keyless::Hash::SHA2::SHA256 as Hash
+import Primitive::Keyless::Hash::SHA2Imperative::SHA256 as Hash
 
 /**
  * ECDSA signature generation algorithm.

--- a/Primitive/Asymmetric/Signature/RSA_PSS_SHA384.cry
+++ b/Primitive/Asymmetric/Signature/RSA_PSS_SHA384.cry
@@ -1,5 +1,6 @@
 /*
-   Copyright (c) 2021, Galois Inc.
+   @copyright Galois Inc. 2021
+   @author Andrei Stefanescu
    www.cryptol.net
 */
 

--- a/Primitive/Asymmetric/Signature/RSA_PSS_SHA384.cry
+++ b/Primitive/Asymmetric/Signature/RSA_PSS_SHA384.cry
@@ -5,7 +5,7 @@
 
 module Primitive::Asymmetric::Signature::RSA_PSS_SHA384 = Primitive::Asymmetric::Signature::RSA_PSS where
 
-import Primitive::Keyless::Hash::SHA2::SHA384
+import Primitive::Keyless::Hash::SHA2Imperative::SHA384
 
 type hLen = 48
 hash = SHAImp

--- a/Primitive/Keyless/Hash/HMAC.cry
+++ b/Primitive/Keyless/Hash/HMAC.cry
@@ -1,5 +1,6 @@
 /*
-   Copyright (c) 2020, Galois Inc.
+   @copyright Galois Inc. 2020
+   @author Brett Boston
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/HMAC.cry
+++ b/Primitive/Keyless/Hash/HMAC.cry
@@ -9,7 +9,7 @@
 
 module Primitive::Keyless::Hash::HMAC where
 
-import Primitive::Keyless::Hash::SHA2::SHA384
+import Primitive::Keyless::Hash::SHA2Imperative::SHA384
 
 // Pad or hash `key`, depending on its length, until it is 128 bytes long
 key_init : {key_size} (fin key_size) => [key_size][8] -> [128][8]

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -1,0 +1,36 @@
+/*
+SHA2 specification.
+
+References
+[FIPS-180-4]: National Institute of Standards and Technology. Secure Hash
+  Standard (SHS). (Department of Commerce, Washington, D.C.), Federal
+  Information Processing Standards Publication (FIPS) NIST FIPS 180-4.
+  August 2015.
+  @see https://doi.org/10.6028/NIST.FIPS.180-4
+
+*/
+module Primitive::Keyless::Hash::SHA2::Specification where
+
+
+/**
+ * Circular rotate left operation.
+ * [FIPS-180-4] Section 2.2.2.
+ */
+ROTL : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+ROTL n x = x <<< (fromZ n)
+
+/**
+ * Circular rotate right operation.
+ * [FIPS-180-4] Section 2.2.2.
+ */
+ROTR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+ROTR n x = x >>> (fromZ n)
+
+/**
+ * Right shift operation.
+ * [FIPS-180-4] Section 2.2.2.
+ */
+SHR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+SHR n x = x >> (fromZ n)
+
+

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -136,6 +136,44 @@ sigma1 x
     | w == 32 => ROTR 17 x ^ ROTR 19 x ^ ROTR 10 x
     | w == 64 => ROTR 19 x ^ ROTR 61 x ^ ROTR  6 x
 
-
-
-
+/**
+ * The SHA family uses a sequence of constant `w`-bit words, which represent
+ * the first `w` bits of the fractional parts of the cube roots of the first
+ * `n` prime numbers.
+ *
+ * `n` is fixed based on `w`: 64 when `w = 32` and 80 when `w = 64`. This is
+ * encoded into the type of `K` using the relation `48 + w/2`.
+ *
+ * [FIPS-180-4] Section 4.2.2 and 4.2.3.
+ */
+K : [48 + w / 2][w]
+K | w == 32 =>
+    [ 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+      0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+      0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+      0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
+  | w == 64 =>
+      [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+        0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+        0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+        0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+        0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+        0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+        0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+        0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+        0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+        0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+        0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+        0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+        0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+        0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+        0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+        0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+        0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+        0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+        0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+        0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817]

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -11,30 +11,37 @@ References
 */
 module Primitive::Keyless::Hash::SHA2::Specification where
 
+parameter
+    /**
+     * Word size.
+     * The specification defines words to be either 32 or 64 bits.
+     * [FIPS-180-4] Section 1, Figure 1.
+     */
+    type w : #
+    type constraint (fin w, w % 32 == 0, 1 <= w / 32, 2 >= w / 32)
 
 /**
  * Circular rotate left operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
  */
-ROTL : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+ROTL : Z w -> [w] -> [w]
 ROTL n x = x <<< (fromZ n)
 
 /**
  * Circular rotate right operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
  */
-ROTR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+ROTR : Z w -> [w] -> [w]
 ROTR n x = x >>> (fromZ n)
 
 /**
  * Circular rotations have a specific kind of circularity.
  * [FIPS-180-4] Section 3.2 #6.
  * ```repl
- * :prove rotationEquivalenceRelationsHold`{32}
- * :prove rotationEquivalenceRelationsHold`{64}
+ * :prove rotationEquivalenceRelationsHold
  * ```
  */
-rotationEquivalenceRelationsHold : {w} (fin w, w > 0) => Z w -> [w] -> Bool
+rotationEquivalenceRelationsHold : Z w -> [w] -> Bool
 property rotationEquivalenceRelationsHold n x = left && right where
     left = ROTL n x == ROTR w_n x
     right = ROTR n x == ROTL w_n x
@@ -44,7 +51,7 @@ property rotationEquivalenceRelationsHold n x = left && right where
  * Right shift operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
  */
-SHR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
+SHR : Z w -> [w] -> [w]
 SHR n x = x >> (fromZ n)
 
 /**
@@ -78,3 +85,57 @@ property wordsEncodeCorrectly = short && long where
  * ```
  */
 property integersEncodeCorrectly = 291 == 0x00000123
+
+/**
+ * The first logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.2 and Section 4.1.3, Equation 4.8.
+ */
+Ch : [w] -> [w] -> [w] -> [w]
+Ch x y z = (x && y) ^ (~x && z)
+
+/**
+ * The second logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.3 and Section 4.1.3, Equation 4.9.
+ */
+Maj : [w] -> [w] -> [w] -> [w]
+Maj x y z = (x && y) ^ (x && z) ^ (y && z)
+
+/**
+ * The third logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.4 and Section 4.1.3, Equation 4.10.
+ */
+Sigma0: [w] -> [w]
+Sigma0 x
+    | w == 32 => ROTR  2 x ^ ROTR 13 x ^ ROTR 22 x
+    | w == 64 => ROTR 28 x ^ ROTR 34 x ^ ROTR 39 x
+
+/**
+ * The fourth logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.5 and Section 4.1.3, Equation 4.11.
+ */
+Sigma1: [w] -> [w]
+Sigma1 x
+    | w == 32 => ROTR  6 x ^ ROTR 11 x ^ ROTR 25 x
+    | w == 64 => ROTR 14 x ^ ROTR 18 x ^ ROTR 41 x
+
+/**
+ * The fifth logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.6 and Section 4.1.3, Equation 4.12.
+ */
+sigma0: [w] -> [w]
+sigma0 x
+    | w == 32 => ROTR 7 x ^ ROTR 18 x ^ ROTR 3 x
+    | w == 64 => ROTR 1 x ^ ROTR  8 x ^ ROTR 7 x
+
+/**
+ * The sixth logical function for the SHA family.
+ * [FIPS-180-4] Section 4.1.2, Equation 4.7 and Section 4.1.3, Equation 4.13.
+ */
+sigma1: [w] -> [w]
+sigma1 x
+    | w == 32 => ROTR 17 x ^ ROTR 19 x ^ ROTR 10 x
+    | w == 64 => ROTR 19 x ^ ROTR 61 x ^ ROTR  6 x
+
+
+
+

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -14,23 +14,67 @@ module Primitive::Keyless::Hash::SHA2::Specification where
 
 /**
  * Circular rotate left operation.
- * [FIPS-180-4] Section 2.2.2.
+ * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
  */
 ROTL : {w} (fin w, w > 0) => Z w -> [w] -> [w]
 ROTL n x = x <<< (fromZ n)
 
 /**
  * Circular rotate right operation.
- * [FIPS-180-4] Section 2.2.2.
+ * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
  */
 ROTR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
 ROTR n x = x >>> (fromZ n)
 
 /**
+ * Circular rotations have a specific kind of circularity.
+ * [FIPS-180-4] Section 3.2 #6.
+ * ```repl
+ * :prove rotationEquivalenceRelationsHold`{32}
+ * :prove rotationEquivalenceRelationsHold`{64}
+ * ```
+ */
+rotationEquivalenceRelationsHold : {w} (fin w, w > 0) => Z w -> [w] -> Bool
+property rotationEquivalenceRelationsHold n x = left && right where
+    left = ROTL n x == ROTR w_n x
+    right = ROTR n x == ROTL w_n x
+    w_n = (fromInteger `w) - n
+
+/**
  * Right shift operation.
- * [FIPS-180-4] Section 2.2.2.
+ * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
  */
 SHR : {w} (fin w, w > 0) => Z w -> [w] -> [w]
 SHR n x = x >> (fromZ n)
 
+/**
+ * The default Cryptol representation of hex digits and bit strings matches
+ * the requirements of the spec.
+ * [FIPS-180-4] Section 3.1, #1.
+ * ```repl
+ * :prove hexDigitsEncodeCorrectly
+ * ```
+ */
+property hexDigitsEncodeCorrectly = (0x7 == 0b0111) && (0xa == 0b1010)
 
+/**
+ * The default Cryptol representation of hex words and bit strings matches
+ * the requirements of the spec.
+ * [FIPS-180-4] Section 3.1, #2.
+ * ```repl
+ * :prove wordsEncodeCorrectly
+ * ```
+ */
+property wordsEncodeCorrectly = short && long where
+    short = 0xa103fe23 == 0b10100001000000111111111000100011
+    long = 0xa103fe2332ef301a == 0b1010000100000011111111100010001100110010111011110011000000011010
+
+/**
+ * The default Cryptol representation of integers and hex words matches
+ * the requirements of the spec.
+ * [FIPS-180-4] Section 3.1, #3.
+ * ```repl
+ * :prove integersEncodeCorrectly
+ * ```
+ */
+property integersEncodeCorrectly = 291 == 0x00000123

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -16,6 +16,9 @@ References
   August 2015.
   @see https://doi.org/10.6028/NIST.FIPS.180-4
 
+@copyright Galois, Inc.
+@author Marcella Hastings <marcella@galois.com>
+
 */
 module Primitive::Keyless::Hash::SHA2::Specification where
 

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -48,8 +48,13 @@ ROTR x = x >>> `n
 /**
  * Circular rotations have a specific kind of circularity.
  * [FIPS-180-4] Section 3.2 #6.
+ *
+ * We check this for a sampling of `n`s.
  * ```repl
- * :prove rotationEquivalenceRelationsHold
+ * :prove rotationEquivalenceRelationsHold`{0}
+ * :prove rotationEquivalenceRelationsHold`{1}
+ * :prove rotationEquivalenceRelationsHold`{w-1}
+ * :prove rotationEquivalenceRelationsHold`{w/2}
  * ```
  */
 rotationEquivalenceRelationsHold : {n} (n < w) => [w] -> Bool

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -1,25 +1,25 @@
 /*
-Implementation of the secure hash algorithms known as SHA2 from [FIPS-180-4].
-
-This implementation does not support SHA-1. It does support:
-- SHA-224
-- SHA-256
-- SHA-384
-- SHA-512
-- SHA-512/224
-- SHA-512/256
-
-References
-[FIPS-180-4]: National Institute of Standards and Technology. Secure Hash
-  Standard (SHS). (Department of Commerce, Washington, D.C.), Federal
-  Information Processing Standards Publication (FIPS) NIST FIPS 180-4.
-  August 2015.
-  @see https://doi.org/10.6028/NIST.FIPS.180-4
-
-@copyright Galois, Inc.
-@author Marcella Hastings <marcella@galois.com>
-
-*/
+ * Implementation of the secure hash algorithms known as SHA2 from [FIPS-180-4].
+ *
+ * This implementation does not support SHA-1. It does support:
+ * - SHA-224
+ * - SHA-256
+ * - SHA-384
+ * - SHA-512
+ * - SHA-512/224
+ * - SHA-512/256
+ *
+ * References
+ * [FIPS-180-4]: National Institute of Standards and Technology. Secure Hash
+ *     Standard (SHS). (Department of Commerce, Washington, D.C.), Federal
+ *     Information Processing Standards Publication (FIPS) NIST FIPS 180-4.
+ *     August 2015.
+ *     @see https://doi.org/10.6028/NIST.FIPS.180-4
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ *
+ */
 module Primitive::Keyless::Hash::SHA2::Specification where
 
 parameter
@@ -33,163 +33,163 @@ parameter
 
 private
     /**
-    * Circular rotate left operation.
-    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
-    */
+     * Circular rotate left operation.
+     * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
+     */
     ROTL : {n} (n < w) => [w] -> [w]
     ROTL x = x <<< `n
 
     /**
-    * Circular rotate right operation.
-    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
-    */
+     * Circular rotate right operation.
+     * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
+     */
     ROTR : {n} (n < w) => [w] -> [w]
     ROTR x = x >>> `n
 
     /**
-    * Circular rotations have a specific kind of circularity.
-    * [FIPS-180-4] Section 3.2 #6.
-    *
-    * We check this for a sampling of `n`s.
-    * ```repl
-    * :prove rotationEquivalenceRelationsHold`{0}
-    * :prove rotationEquivalenceRelationsHold`{1}
-    * :prove rotationEquivalenceRelationsHold`{w-1}
-    * :prove rotationEquivalenceRelationsHold`{w/2}
-    * ```
-    */
+     * Circular rotations have a specific kind of circularity.
+     * [FIPS-180-4] Section 3.2 #6.
+     *
+     * We check this for a sampling of `n`s.
+     * ```repl
+     * :prove rotationEquivalenceRelationsHold`{0}
+     * :prove rotationEquivalenceRelationsHold`{1}
+     * :prove rotationEquivalenceRelationsHold`{w-1}
+     * :prove rotationEquivalenceRelationsHold`{w/2}
+     * ```
+     */
     rotationEquivalenceRelationsHold : {n} (n < w) => [w] -> Bool
     property rotationEquivalenceRelationsHold x = left && right where
         left = ROTL`{n} x == ROTR`{(w - n) % w} x
         right = ROTR`{n} x == ROTL`{(w - n) % w} x
 
     /**
-    * Right shift operation.
-    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
-    */
+     * Right shift operation.
+     * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
+     */
     SHR : {n} (n < w) => [w] -> [w]
     SHR x = x >> `n
 
     /**
-    * The default Cryptol representation of hex digits and bit strings matches
-    * the requirements of the spec.
-    * [FIPS-180-4] Section 3.1, #1.
-    * ```repl
-    * :prove hexDigitsEncodeCorrectly
-    * ```
-    */
+     * The default Cryptol representation of hex digits and bit strings matches
+     * the requirements of the spec.
+     * [FIPS-180-4] Section 3.1, #1.
+     * ```repl
+     * :prove hexDigitsEncodeCorrectly
+     * ```
+     */
     property hexDigitsEncodeCorrectly = (0x7 == 0b0111) && (0xa == 0b1010)
 
     /**
-    * The default Cryptol representation of hex words and bit strings matches
-    * the requirements of the spec.
-    * [FIPS-180-4] Section 3.1, #2.
-    * ```repl
-    * :prove wordsEncodeCorrectly
-    * ```
-    */
+     * The default Cryptol representation of hex words and bit strings matches
+     * the requirements of the spec.
+     * [FIPS-180-4] Section 3.1, #2.
+     * ```repl
+     * :prove wordsEncodeCorrectly
+     * ```
+     */
     property wordsEncodeCorrectly = short && long where
         short = 0xa103fe23 == 0b10100001000000111111111000100011
         long = 0xa103fe2332ef301a == 0b1010000100000011111111100010001100110010111011110011000000011010
 
     /**
-    * The default Cryptol representation of integers and hex words matches
-    * the requirements of the spec.
-    * [FIPS-180-4] Section 3.1, #3.
-    * ```repl
-    * :prove integersEncodeCorrectly
-    * ```
-    */
+     * The default Cryptol representation of integers and hex words matches
+     * the requirements of the spec.
+     * [FIPS-180-4] Section 3.1, #3.
+     * ```repl
+     * :prove integersEncodeCorrectly
+     * ```
+     */
     property integersEncodeCorrectly = 291 == 0x00000123
 
     /**
-    * The first logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.2 and Section 4.1.3, Equation 4.8.
-    */
+     * The first logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.2 and Section 4.1.3, Equation 4.8.
+     */
     Ch : [w] -> [w] -> [w] -> [w]
     Ch x y z = (x && y) ^ (~x && z)
 
     /**
-    * The second logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.3 and Section 4.1.3, Equation 4.9.
-    */
+     * The second logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.3 and Section 4.1.3, Equation 4.9.
+     */
     Maj : [w] -> [w] -> [w] -> [w]
     Maj x y z = (x && y) ^ (x && z) ^ (y && z)
 
     /**
-    * The third logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.4 and Section 4.1.3, Equation 4.10.
-    */
+     * The third logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.4 and Section 4.1.3, Equation 4.10.
+     */
     Sigma0: [w] -> [w]
     Sigma0 x
         | w == 32 => ROTR`{ 2} x ^ ROTR`{13} x ^ ROTR`{22} x
         | w == 64 => ROTR`{28} x ^ ROTR`{34} x ^ ROTR`{39} x
 
     /**
-    * The fourth logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.5 and Section 4.1.3, Equation 4.11.
-    */
+     * The fourth logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.5 and Section 4.1.3, Equation 4.11.
+     */
     Sigma1: [w] -> [w]
     Sigma1 x
         | w == 32 => ROTR`{ 6} x ^ ROTR`{11} x ^ ROTR`{25} x
         | w == 64 => ROTR`{14} x ^ ROTR`{18} x ^ ROTR`{41} x
 
     /**
-    * The fifth logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.6 and Section 4.1.3, Equation 4.12.
-    */
+     * The fifth logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.6 and Section 4.1.3, Equation 4.12.
+     */
     sigma0: [w] -> [w]
     sigma0 x
         | w == 32 => ROTR`{7} x ^ ROTR`{18} x ^ SHR`{3} x
         | w == 64 => ROTR`{1} x ^ ROTR`{ 8} x ^ SHR`{7} x
 
     /**
-    * The sixth logical function for the SHA family.
-    * [FIPS-180-4] Section 4.1.2, Equation 4.7 and Section 4.1.3, Equation 4.13.
-    */
+     * The sixth logical function for the SHA family.
+     * [FIPS-180-4] Section 4.1.2, Equation 4.7 and Section 4.1.3, Equation 4.13.
+     */
     sigma1: [w] -> [w]
     sigma1 x
         | w == 32 => ROTR`{17} x ^ ROTR`{19} x ^ SHR`{10} x
         | w == 64 => ROTR`{19} x ^ ROTR`{61} x ^ SHR`{ 6} x
 
     /**
-    * The SHA family uses a sequence of constant `w`-bit words, which represent
-    * the first `w` bits of the fractional parts of the cube roots of the first
-    * `n` prime numbers.
-    *
-    * `n` is fixed based on `w`: 64 when `w = 32` and 80 when `w = 64`. This is
-    * encoded into the type of `K` using the relation `48 + w/2`.
-    *
-    * [FIPS-180-4] Section 4.2.2 and 4.2.3.
-    */
+     * The SHA family uses a sequence of constant `w`-bit words, which represent
+     * the first `w` bits of the fractional parts of the cube roots of the first
+     * `n` prime numbers.
+     *
+     * `n` is fixed based on `w`: 64 when `w = 32` and 80 when `w = 64`. This is
+     * encoded into the type of `K` using the relation `48 + w/2`.
+     *
+     * [FIPS-180-4] Section 4.2.2 and 4.2.3.
+     */
     K : [48 + w / 2][w]
-    K | w == 32 =>
-        [ 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-          0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-          0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-          0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-          0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-          0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-          0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-          0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
-      | w == 64 =>
-        [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
-          0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
-          0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
-          0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
-          0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
-          0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
-          0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
-          0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
-          0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
-          0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
-          0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
-          0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
-          0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
-          0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
-          0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
-          0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
-          0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
-          0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
-          0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
-          0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817]
+    K | w == 32 => [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+        0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+        0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+        0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+        0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+        0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+        0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
+      | w == 64 => [
+        0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+        0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+        0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+        0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+        0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+        0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+        0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+        0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+        0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+        0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+        0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+        0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+        0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+        0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+        0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+        0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+        0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+        0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+        0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+        0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817]

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -1,5 +1,13 @@
 /*
-SHA2 specification.
+Implementation of the secure hash algorithms known as SHA2 from [FIPS-180-4].
+
+This implementation does not include SHA-1. It does include:
+- SHA-224
+- SHA-256
+- SHA-384
+- SHA-512
+- SHA-512/224
+- SHA-512/256
 
 References
 [FIPS-180-4]: National Institute of Standards and Technology. Secure Hash

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -29,21 +29,21 @@ parameter
      * [FIPS-180-4] Section 1, Figure 1.
      */
     type w : #
-    type constraint (fin w, w % 32 == 0, 1 <= w / 32, 2 >= w / 32)
+    type constraint (w % 32 == 0, 32 <= w, 64 >= w)
 
 /**
  * Circular rotate left operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
  */
-ROTL : Z w -> [w] -> [w]
-ROTL n x = x <<< (fromZ n)
+ROTL : {n} (n < w) => [w] -> [w]
+ROTL x = x <<< `n
 
 /**
  * Circular rotate right operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
  */
-ROTR : Z w -> [w] -> [w]
-ROTR n x = x >>> (fromZ n)
+ROTR : {n} (n < w) => [w] -> [w]
+ROTR x = x >>> `n
 
 /**
  * Circular rotations have a specific kind of circularity.
@@ -52,18 +52,17 @@ ROTR n x = x >>> (fromZ n)
  * :prove rotationEquivalenceRelationsHold
  * ```
  */
-rotationEquivalenceRelationsHold : Z w -> [w] -> Bool
-property rotationEquivalenceRelationsHold n x = left && right where
-    left = ROTL n x == ROTR w_n x
-    right = ROTR n x == ROTL w_n x
-    w_n = (fromInteger `w) - n
+rotationEquivalenceRelationsHold : {n} (n < w) => [w] -> Bool
+property rotationEquivalenceRelationsHold x = left && right where
+    left = ROTL`{n} x == ROTR`{(w - n) % w} x
+    right = ROTR`{n} x == ROTL`{(w - n) % w} x
 
 /**
  * Right shift operation.
  * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
  */
-SHR : Z w -> [w] -> [w]
-SHR n x = x >> (fromZ n)
+SHR : {n} (n < w) => [w] -> [w]
+SHR x = x >> `n
 
 /**
  * The default Cryptol representation of hex digits and bit strings matches
@@ -117,8 +116,8 @@ Maj x y z = (x && y) ^ (x && z) ^ (y && z)
  */
 Sigma0: [w] -> [w]
 Sigma0 x
-    | w == 32 => ROTR  2 x ^ ROTR 13 x ^ ROTR 22 x
-    | w == 64 => ROTR 28 x ^ ROTR 34 x ^ ROTR 39 x
+    | w == 32 => ROTR`{ 2} x ^ ROTR`{13} x ^ ROTR`{22} x
+    | w == 64 => ROTR`{28} x ^ ROTR`{34} x ^ ROTR`{39} x
 
 /**
  * The fourth logical function for the SHA family.
@@ -126,8 +125,8 @@ Sigma0 x
  */
 Sigma1: [w] -> [w]
 Sigma1 x
-    | w == 32 => ROTR  6 x ^ ROTR 11 x ^ ROTR 25 x
-    | w == 64 => ROTR 14 x ^ ROTR 18 x ^ ROTR 41 x
+    | w == 32 => ROTR`{ 6} x ^ ROTR`{11} x ^ ROTR`{25} x
+    | w == 64 => ROTR`{14} x ^ ROTR`{18} x ^ ROTR`{41} x
 
 /**
  * The fifth logical function for the SHA family.
@@ -135,8 +134,8 @@ Sigma1 x
  */
 sigma0: [w] -> [w]
 sigma0 x
-    | w == 32 => ROTR 7 x ^ ROTR 18 x ^ ROTR 3 x
-    | w == 64 => ROTR 1 x ^ ROTR  8 x ^ ROTR 7 x
+    | w == 32 => ROTR`{7} x ^ ROTR`{18} x ^ SHR`{3} x
+    | w == 64 => ROTR`{1} x ^ ROTR`{ 8} x ^ SHR`{7} x
 
 /**
  * The sixth logical function for the SHA family.
@@ -144,8 +143,8 @@ sigma0 x
  */
 sigma1: [w] -> [w]
 sigma1 x
-    | w == 32 => ROTR 17 x ^ ROTR 19 x ^ ROTR 10 x
-    | w == 64 => ROTR 19 x ^ ROTR 61 x ^ ROTR  6 x
+    | w == 32 => ROTR`{17} x ^ ROTR`{19} x ^ SHR`{10} x
+    | w == 64 => ROTR`{19} x ^ ROTR`{61} x ^ SHR`{ 6} x
 
 /**
  * The SHA family uses a sequence of constant `w`-bit words, which represent

--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -1,7 +1,7 @@
 /*
 Implementation of the secure hash algorithms known as SHA2 from [FIPS-180-4].
 
-This implementation does not include SHA-1. It does include:
+This implementation does not support SHA-1. It does support:
 - SHA-224
 - SHA-256
 - SHA-384
@@ -31,164 +31,165 @@ parameter
     type w : #
     type constraint (w % 32 == 0, 32 <= w, 64 >= w)
 
-/**
- * Circular rotate left operation.
- * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
- */
-ROTL : {n} (n < w) => [w] -> [w]
-ROTL x = x <<< `n
+private
+    /**
+    * Circular rotate left operation.
+    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #5.
+    */
+    ROTL : {n} (n < w) => [w] -> [w]
+    ROTL x = x <<< `n
 
-/**
- * Circular rotate right operation.
- * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
- */
-ROTR : {n} (n < w) => [w] -> [w]
-ROTR x = x >>> `n
+    /**
+    * Circular rotate right operation.
+    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #4.
+    */
+    ROTR : {n} (n < w) => [w] -> [w]
+    ROTR x = x >>> `n
 
-/**
- * Circular rotations have a specific kind of circularity.
- * [FIPS-180-4] Section 3.2 #6.
- *
- * We check this for a sampling of `n`s.
- * ```repl
- * :prove rotationEquivalenceRelationsHold`{0}
- * :prove rotationEquivalenceRelationsHold`{1}
- * :prove rotationEquivalenceRelationsHold`{w-1}
- * :prove rotationEquivalenceRelationsHold`{w/2}
- * ```
- */
-rotationEquivalenceRelationsHold : {n} (n < w) => [w] -> Bool
-property rotationEquivalenceRelationsHold x = left && right where
-    left = ROTL`{n} x == ROTR`{(w - n) % w} x
-    right = ROTR`{n} x == ROTL`{(w - n) % w} x
+    /**
+    * Circular rotations have a specific kind of circularity.
+    * [FIPS-180-4] Section 3.2 #6.
+    *
+    * We check this for a sampling of `n`s.
+    * ```repl
+    * :prove rotationEquivalenceRelationsHold`{0}
+    * :prove rotationEquivalenceRelationsHold`{1}
+    * :prove rotationEquivalenceRelationsHold`{w-1}
+    * :prove rotationEquivalenceRelationsHold`{w/2}
+    * ```
+    */
+    rotationEquivalenceRelationsHold : {n} (n < w) => [w] -> Bool
+    property rotationEquivalenceRelationsHold x = left && right where
+        left = ROTL`{n} x == ROTR`{(w - n) % w} x
+        right = ROTR`{n} x == ROTL`{(w - n) % w} x
 
-/**
- * Right shift operation.
- * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
- */
-SHR : {n} (n < w) => [w] -> [w]
-SHR x = x >> `n
+    /**
+    * Right shift operation.
+    * [FIPS-180-4] Section 2.2.2 and Section 3.2 #3
+    */
+    SHR : {n} (n < w) => [w] -> [w]
+    SHR x = x >> `n
 
-/**
- * The default Cryptol representation of hex digits and bit strings matches
- * the requirements of the spec.
- * [FIPS-180-4] Section 3.1, #1.
- * ```repl
- * :prove hexDigitsEncodeCorrectly
- * ```
- */
-property hexDigitsEncodeCorrectly = (0x7 == 0b0111) && (0xa == 0b1010)
+    /**
+    * The default Cryptol representation of hex digits and bit strings matches
+    * the requirements of the spec.
+    * [FIPS-180-4] Section 3.1, #1.
+    * ```repl
+    * :prove hexDigitsEncodeCorrectly
+    * ```
+    */
+    property hexDigitsEncodeCorrectly = (0x7 == 0b0111) && (0xa == 0b1010)
 
-/**
- * The default Cryptol representation of hex words and bit strings matches
- * the requirements of the spec.
- * [FIPS-180-4] Section 3.1, #2.
- * ```repl
- * :prove wordsEncodeCorrectly
- * ```
- */
-property wordsEncodeCorrectly = short && long where
-    short = 0xa103fe23 == 0b10100001000000111111111000100011
-    long = 0xa103fe2332ef301a == 0b1010000100000011111111100010001100110010111011110011000000011010
+    /**
+    * The default Cryptol representation of hex words and bit strings matches
+    * the requirements of the spec.
+    * [FIPS-180-4] Section 3.1, #2.
+    * ```repl
+    * :prove wordsEncodeCorrectly
+    * ```
+    */
+    property wordsEncodeCorrectly = short && long where
+        short = 0xa103fe23 == 0b10100001000000111111111000100011
+        long = 0xa103fe2332ef301a == 0b1010000100000011111111100010001100110010111011110011000000011010
 
-/**
- * The default Cryptol representation of integers and hex words matches
- * the requirements of the spec.
- * [FIPS-180-4] Section 3.1, #3.
- * ```repl
- * :prove integersEncodeCorrectly
- * ```
- */
-property integersEncodeCorrectly = 291 == 0x00000123
+    /**
+    * The default Cryptol representation of integers and hex words matches
+    * the requirements of the spec.
+    * [FIPS-180-4] Section 3.1, #3.
+    * ```repl
+    * :prove integersEncodeCorrectly
+    * ```
+    */
+    property integersEncodeCorrectly = 291 == 0x00000123
 
-/**
- * The first logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.2 and Section 4.1.3, Equation 4.8.
- */
-Ch : [w] -> [w] -> [w] -> [w]
-Ch x y z = (x && y) ^ (~x && z)
+    /**
+    * The first logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.2 and Section 4.1.3, Equation 4.8.
+    */
+    Ch : [w] -> [w] -> [w] -> [w]
+    Ch x y z = (x && y) ^ (~x && z)
 
-/**
- * The second logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.3 and Section 4.1.3, Equation 4.9.
- */
-Maj : [w] -> [w] -> [w] -> [w]
-Maj x y z = (x && y) ^ (x && z) ^ (y && z)
+    /**
+    * The second logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.3 and Section 4.1.3, Equation 4.9.
+    */
+    Maj : [w] -> [w] -> [w] -> [w]
+    Maj x y z = (x && y) ^ (x && z) ^ (y && z)
 
-/**
- * The third logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.4 and Section 4.1.3, Equation 4.10.
- */
-Sigma0: [w] -> [w]
-Sigma0 x
-    | w == 32 => ROTR`{ 2} x ^ ROTR`{13} x ^ ROTR`{22} x
-    | w == 64 => ROTR`{28} x ^ ROTR`{34} x ^ ROTR`{39} x
+    /**
+    * The third logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.4 and Section 4.1.3, Equation 4.10.
+    */
+    Sigma0: [w] -> [w]
+    Sigma0 x
+        | w == 32 => ROTR`{ 2} x ^ ROTR`{13} x ^ ROTR`{22} x
+        | w == 64 => ROTR`{28} x ^ ROTR`{34} x ^ ROTR`{39} x
 
-/**
- * The fourth logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.5 and Section 4.1.3, Equation 4.11.
- */
-Sigma1: [w] -> [w]
-Sigma1 x
-    | w == 32 => ROTR`{ 6} x ^ ROTR`{11} x ^ ROTR`{25} x
-    | w == 64 => ROTR`{14} x ^ ROTR`{18} x ^ ROTR`{41} x
+    /**
+    * The fourth logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.5 and Section 4.1.3, Equation 4.11.
+    */
+    Sigma1: [w] -> [w]
+    Sigma1 x
+        | w == 32 => ROTR`{ 6} x ^ ROTR`{11} x ^ ROTR`{25} x
+        | w == 64 => ROTR`{14} x ^ ROTR`{18} x ^ ROTR`{41} x
 
-/**
- * The fifth logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.6 and Section 4.1.3, Equation 4.12.
- */
-sigma0: [w] -> [w]
-sigma0 x
-    | w == 32 => ROTR`{7} x ^ ROTR`{18} x ^ SHR`{3} x
-    | w == 64 => ROTR`{1} x ^ ROTR`{ 8} x ^ SHR`{7} x
+    /**
+    * The fifth logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.6 and Section 4.1.3, Equation 4.12.
+    */
+    sigma0: [w] -> [w]
+    sigma0 x
+        | w == 32 => ROTR`{7} x ^ ROTR`{18} x ^ SHR`{3} x
+        | w == 64 => ROTR`{1} x ^ ROTR`{ 8} x ^ SHR`{7} x
 
-/**
- * The sixth logical function for the SHA family.
- * [FIPS-180-4] Section 4.1.2, Equation 4.7 and Section 4.1.3, Equation 4.13.
- */
-sigma1: [w] -> [w]
-sigma1 x
-    | w == 32 => ROTR`{17} x ^ ROTR`{19} x ^ SHR`{10} x
-    | w == 64 => ROTR`{19} x ^ ROTR`{61} x ^ SHR`{ 6} x
+    /**
+    * The sixth logical function for the SHA family.
+    * [FIPS-180-4] Section 4.1.2, Equation 4.7 and Section 4.1.3, Equation 4.13.
+    */
+    sigma1: [w] -> [w]
+    sigma1 x
+        | w == 32 => ROTR`{17} x ^ ROTR`{19} x ^ SHR`{10} x
+        | w == 64 => ROTR`{19} x ^ ROTR`{61} x ^ SHR`{ 6} x
 
-/**
- * The SHA family uses a sequence of constant `w`-bit words, which represent
- * the first `w` bits of the fractional parts of the cube roots of the first
- * `n` prime numbers.
- *
- * `n` is fixed based on `w`: 64 when `w = 32` and 80 when `w = 64`. This is
- * encoded into the type of `K` using the relation `48 + w/2`.
- *
- * [FIPS-180-4] Section 4.2.2 and 4.2.3.
- */
-K : [48 + w / 2][w]
-K | w == 32 =>
-    [ 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-      0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-      0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-      0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-      0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-      0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-      0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-      0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
-  | w == 64 =>
-      [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
-        0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
-        0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
-        0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
-        0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
-        0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
-        0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
-        0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
-        0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
-        0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
-        0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
-        0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
-        0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
-        0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
-        0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
-        0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
-        0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
-        0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
-        0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
-        0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817]
+    /**
+    * The SHA family uses a sequence of constant `w`-bit words, which represent
+    * the first `w` bits of the fractional parts of the cube roots of the first
+    * `n` prime numbers.
+    *
+    * `n` is fixed based on `w`: 64 when `w = 32` and 80 when `w = 64`. This is
+    * encoded into the type of `K` using the relation `48 + w/2`.
+    *
+    * [FIPS-180-4] Section 4.2.2 and 4.2.3.
+    */
+    K : [48 + w / 2][w]
+    K | w == 32 =>
+        [ 0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+          0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+          0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+          0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+          0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+          0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+          0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+          0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2]
+      | w == 64 =>
+        [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
+          0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,
+          0xd807aa98a3030242, 0x12835b0145706fbe, 0x243185be4ee4b28c, 0x550c7dc3d5ffb4e2,
+          0x72be5d74f27b896f, 0x80deb1fe3b1696b1, 0x9bdc06a725c71235, 0xc19bf174cf692694,
+          0xe49b69c19ef14ad2, 0xefbe4786384f25e3, 0x0fc19dc68b8cd5b5, 0x240ca1cc77ac9c65,
+          0x2de92c6f592b0275, 0x4a7484aa6ea6e483, 0x5cb0a9dcbd41fbd4, 0x76f988da831153b5,
+          0x983e5152ee66dfab, 0xa831c66d2db43210, 0xb00327c898fb213f, 0xbf597fc7beef0ee4,
+          0xc6e00bf33da88fc2, 0xd5a79147930aa725, 0x06ca6351e003826f, 0x142929670a0e6e70,
+          0x27b70a8546d22ffc, 0x2e1b21385c26c926, 0x4d2c6dfc5ac42aed, 0x53380d139d95b3df,
+          0x650a73548baf63de, 0x766a0abb3c77b2a8, 0x81c2c92e47edaee6, 0x92722c851482353b,
+          0xa2bfe8a14cf10364, 0xa81a664bbc423001, 0xc24b8b70d0f89791, 0xc76c51a30654be30,
+          0xd192e819d6ef5218, 0xd69906245565a910, 0xf40e35855771202a, 0x106aa07032bbd1b8,
+          0x19a4c116b8d2d0c8, 0x1e376c085141ab53, 0x2748774cdf8eeb99, 0x34b0bcb5e19b48a8,
+          0x391c0cb3c5c95a63, 0x4ed8aa4ae3418acb, 0x5b9cca4f7763e373, 0x682e6ff3d6b2b8a3,
+          0x748f82ee5defb2fc, 0x78a5636f43172f60, 0x84c87814a1f0ab72, 0x8cc702081a6439ec,
+          0x90befffa23631e28, 0xa4506cebde82bde9, 0xbef9a3f7b2c67915, 0xc67178f2e372532b,
+          0xca273eceea26619c, 0xd186b8c721c0c207, 0xeada7dd6cde0eb1e, 0xf57d4f7fee6ed178,
+          0x06f067aa72176fba, 0x0a637dc5a2c898a6, 0x113f9804bef90dae, 0x1b710b35131c471b,
+          0x28db77f523047d84, 0x32caab7b40c72493, 0x3c9ebe0a15c9bebc, 0x431d67c49c100d4c,
+          0x4cc5d4becb3e42b6, 0x597f299cfc657e2a, 0x5fcb6fab3ad6faec, 0x6c44198c4a475817]

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA.cry
@@ -17,7 +17,7 @@ www.cryptol.net
     @see https://doi.org/10.6028/NIST.SP.800-107r1.
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 import Array
 import Common::ByteArray

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA.cry
@@ -3,7 +3,7 @@
 
 @author Nichole Schmanski <nls@galois.com>
 @editor Sean Weaver
-@editor Github user @msaaltink
+@editor Mark Saaltink
 @editor Sam Breese
 @editor Brett Boston
 @author Andrei Stefanescu
@@ -17,7 +17,7 @@ www.cryptol.net
     @see https://doi.org/10.6028/NIST.SP.800-107r1.
 */
 
-module Primitive::Keyless::Hash::SHA2Imperative::SHA where
+module Primitive::Keyless::Hash::SHA2::SHA where
 
 import Array
 import Common::ByteArray

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA224.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA224.cry
@@ -1,5 +1,7 @@
 /*
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Sean Weaver
+   @editor Sam Breese
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA224.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA224.cry
@@ -3,7 +3,7 @@
    www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA224 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA224 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 32
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA256.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA256.cry
@@ -3,7 +3,7 @@
    www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA256 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA256 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 32
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA256.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA256.cry
@@ -1,5 +1,9 @@
 /*
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Nichole Schimanski <nls@galois.com>
+   @editor Brian Huffman
+   @author Sean Weaver
+   @editor Sam Breese
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA384.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA384.cry
@@ -1,18 +1,18 @@
 /*
-   Copyright (c) 2018, Galois Inc.
-   www.cryptol.net
+Copyright (c) 2018, Galois Inc.
+www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA512 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA384 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 64
 
-type digest_size = 512
+type digest_size = 384
 
 type j = 80
 
-H0 = [ 0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
-       0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179]
+H0 = [ 0xcbbb9d5dc1059ed8, 0x629a292a367cd507, 0x9159015a3070dd17, 0x152fecd8f70e5939,
+       0x67332667ffc00b31, 0x8eb44a8768581511, 0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4]
 
 K = [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
       0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA384.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA384.cry
@@ -1,6 +1,8 @@
 /*
-Copyright (c) 2018, Galois Inc.
-www.cryptol.net
+   @copyright Galois Inc. 2018
+   @author Sean Weaver
+   @editor Sam Breese
+   www.cryptol.net
 */
 
 module Primitive::Keyless::Hash::SHA2Imperative::SHA384 = Primitive::Keyless::Hash::SHA2Imperative::SHA where

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512.cry
@@ -1,5 +1,7 @@
 /*
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Sean Weaver
+   @editor Sam Breese
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512.cry
@@ -3,16 +3,16 @@
    www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA512_256 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA512 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 64
 
-type digest_size = 256
+type digest_size = 512
 
 type j = 80
 
-H0 = [ 0x22312194fc2bf72c, 0x9f555fa3c84c64c2, 0x2393b86b6f53b151, 0x963877195940eabd,
-       0x96283ee2a88effe3, 0xbe5e1e2553863992, 0x2b0199fc2c85b8aa, 0x0eb72ddc81c52ca2]
+H0 = [ 0x6a09e667f3bcc908, 0xbb67ae8584caa73b, 0x3c6ef372fe94f82b, 0xa54ff53a5f1d36f1,
+       0x510e527fade682d1, 0x9b05688c2b3e6c1f, 0x1f83d9abfb41bd6b, 0x5be0cd19137e2179]
 
 K = [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
       0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512_224.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512_224.cry
@@ -3,7 +3,7 @@
    www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA512_224 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA512_224 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 64
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512_224.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512_224.cry
@@ -1,5 +1,7 @@
 /*
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Sean Weaver
+   @editor Sam Breese
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512_256.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512_256.cry
@@ -1,5 +1,7 @@
 /*
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Sean Weaver
+   @editor Sam Breese
    www.cryptol.net
 */
 

--- a/Primitive/Keyless/Hash/SHA2Imperative/SHA512_256.cry
+++ b/Primitive/Keyless/Hash/SHA2Imperative/SHA512_256.cry
@@ -1,18 +1,18 @@
 /*
-Copyright (c) 2018, Galois Inc.
-www.cryptol.net
+   Copyright (c) 2018, Galois Inc.
+   www.cryptol.net
 */
 
-module Primitive::Keyless::Hash::SHA2::SHA384 = Primitive::Keyless::Hash::SHA2::SHA where
+module Primitive::Keyless::Hash::SHA2Imperative::SHA512_256 = Primitive::Keyless::Hash::SHA2Imperative::SHA where
 
 type wp = 64
 
-type digest_size = 384
+type digest_size = 256
 
 type j = 80
 
-H0 = [ 0xcbbb9d5dc1059ed8, 0x629a292a367cd507, 0x9159015a3070dd17, 0x152fecd8f70e5939,
-       0x67332667ffc00b31, 0x8eb44a8768581511, 0xdb0c2e0d64f98fa7, 0x47b5481dbefa4fa4]
+H0 = [ 0x22312194fc2bf72c, 0x9f555fa3c84c64c2, 0x2393b86b6f53b151, 0x963877195940eabd,
+       0x96283ee2a88effe3, 0xbe5e1e2553863992, 0x2b0199fc2c85b8aa, 0x0eb72ddc81c52ca2]
 
 K = [ 0x428a2f98d728ae22, 0x7137449123ef65cd, 0xb5c0fbcfec4d3b2f, 0xe9b5dba58189dbbc,
       0x3956c25bf348b538, 0x59f111f1b605d019, 0x923f82a4af194f9b, 0xab1c5ed5da6d8118,

--- a/Primitive/Symmetric/Cipher/Block/SHACAL.cry
+++ b/Primitive/Symmetric/Cipher/Block/SHACAL.cry
@@ -1,11 +1,15 @@
 /* Cryptol SHACAL Implementation
-   Copyright (c) 2018, Galois Inc.
+   @copyright Galois Inc. 2018
+   @author Ajay Kumar Eeralla
+   @editor Nichole Schmanski <nls@galois.com>
+   @editor Brian Huffman
+   @editor Aaron Tomb
+   @editor Iavor Diatchki <diatchki@galois.com>
    www.cryptol.net
 
    Source: https://www.cosic.esat.kuleuven.be/nessie/tweaks.html
    SHACAL: SHACAL-1, blocksize: 160bits, keysize: 512bits, uses SHA-1 (160bits);
            SHACAL-2, block size: 256bits, key size: 512bits, uses SHA-2 (256bits)
-   Author: Ajay Kumar Eeralla
 */
 
 module Primitive::Symmetric::Cipher::Block::SHACAL where

--- a/Primitive/Symmetric/Cipher/Block/SHACAL.cry
+++ b/Primitive/Symmetric/Cipher/Block/SHACAL.cry
@@ -10,7 +10,7 @@
 
 module Primitive::Symmetric::Cipher::Block::SHACAL where
 
-import Primitive::Keyless::Hash::SHA2::SHA256
+import Primitive::Keyless::Hash::SHA2Imperative::SHA256
 import Primitive::Keyless::Hash::SHA1
 
 /**SHACAL1**/

--- a/Primitive/Symmetric/MAC/HMAC.cry
+++ b/Primitive/Symmetric/MAC/HMAC.cry
@@ -10,7 +10,7 @@
 
 module Primitive::Symmetric::MAC::HMAC where
 
-import Primitive::Keyless::Hash::SHA2::SHA256
+import Primitive::Keyless::Hash::SHA2Imperative::SHA256
 
 //////// Functional version ////////
 

--- a/Primitive/Symmetric/MAC/HMAC.cry
+++ b/Primitive/Symmetric/MAC/HMAC.cry
@@ -1,12 +1,9 @@
-////////////////////////////////////////////////////////////////
-// Copyright 2016-2018 Galois, Inc. All Rights Reserved
-//
-// Authors:
-//      Aaron Tomb : atomb@galois.com
-//	Nathan Collins : conathan@galois.com
-//      Joey Dodds : jdodds@galois.com
-//
-////////////////////////////////////////////////////////////////
+/*
+@copyright Galois, Inc. 2016-2018
+@author Aaron Tomb <atomb@galois.com>
+@author Nathan Collins <conathan@galois.com>
+@author Joey Dodds <jdodds@galois.com>
+*/
 
 module Primitive::Symmetric::MAC::HMAC where
 
@@ -35,7 +32,7 @@ kinit hash key =
   else take `{blockLength} (key # (zero : [blockLength][8]))
 
 // Due to limitations of the type system we must accept two
-// separate arguments (both aledgedly the same) for two
+// separate arguments (both allegedly the same) for two
 // separate length inputs.
 hmac : { msgBytes, pwBytes, digest, blockLength }
        ( fin pwBytes, fin digest, fin blockLength )


### PR DESCRIPTION
Closes #109.

This moves all the existing SHA work (which is a mostly imperative implementation for a specific use case) to a separate directory and defines all the preliminary notation in sections 1-4 of the [FIPS 180-4 spec](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf).

I'm trying to just add parameters as I need them, so this is definitely not complete yet, but it should contain all the properties and definitions from the noted sections.
