### PR TITLE
Update structure of SHA3

### DIFF
--- a/Primitive/Asymmetric/Signature/DSA/p2048_q224.cry
+++ b/Primitive/Asymmetric/Signature/DSA/p2048_q224.cry
@@ -2,7 +2,6 @@ module Primitive::Asymmetric::Signature::DSA::p2048_q224=
     Primitive::Asymmetric::Signature::DSA::DSA where
 import Common::utils
 import Primitive::Keyless::Hash::SHA1
-import Primitive::Keyless::Hash::keccak
 import Primitive::Keyless::Hash::SHA3::SHA3_256
 
 type L = 2048 // p length

--- a/Primitive/Asymmetric/Signature/DSA/p2048_q224.cry
+++ b/Primitive/Asymmetric/Signature/DSA/p2048_q224.cry
@@ -1,3 +1,10 @@
+/*
+ * DSA instantiated with SHA-1 and SHA-3.
+ *
+ * @copyright Galois, Inc
+ * @author Ajay Kumar Eeralla
+ *
+ */
 module Primitive::Asymmetric::Signature::DSA::p2048_q224=
     Primitive::Asymmetric::Signature::DSA::DSA where
 import Common::utils

--- a/Primitive/Keyless/Hash/SHA3/SHA3.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3.cry
@@ -1,3 +1,16 @@
+/*
+ * SHA-3 hash function, as specified in [FIPS-202].
+ *
+ * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
+ *     Permutation-Based Hash and Extendable-Output Functions. (Department of
+ *     Commerce, Washington, D.C.), Federal Information Processing Standards
+ *     Publication (FIPS) NIST FIPS 202. August 2015.
+ *     @see https://dx.doi.org/10.6028/NIST.FIPS.202
+ *
+ * @copyright Galois, Inc.
+ * @author Ajay Kumar Eeralla
+ * @editor Marcella Hastings <marcella@galois.com>
+ */
 module Primitive::Keyless::Hash::SHA3::SHA3 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
@@ -8,5 +21,12 @@ parameter
   type digest : #
   type constraint (fin digest, digest >= 224, digest <= 512)
 
+/**
+ * SHA-3 hash function specification.
+ * [FIPS-202] Section 6.1.
+ *
+ * Note that the specification of `c` is above, in the instantiation of the
+ * `keccak` module.
+ */
 sha3 : {n} (fin n) => [n] -> [digest]
 sha3 M = Keccak`{d=digest} (M # 0b01)

--- a/Primitive/Keyless/Hash/SHA3/SHA3.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3.cry
@@ -1,12 +1,12 @@
 module Primitive::Keyless::Hash::SHA3::SHA3 where
-import Primitive::Keyless::Hash::keccak
+import Primitive::Keyless::Hash::keccak where
+    type b = 1600
+    type nr = 24
 
 parameter
   type digest : #
   type constraint (fin digest, digest >= 224, digest <= 512)
 
-type total = 1600
-
 sha3 : {n} (fin n) => [n] -> [digest]
 sha3 M =
-  take`{digest} (Keccak `{r = total - 2 * digest, c = 2 * digest} (M # 0b01))
+  take`{digest} (Keccak `{r=1600-(2*digest)} (M # 0b01))

--- a/Primitive/Keyless/Hash/SHA3/SHA3.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3.cry
@@ -2,11 +2,11 @@ module Primitive::Keyless::Hash::SHA3::SHA3 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
     type nr = 24
+    type c = 2 * digest
 
 parameter
   type digest : #
   type constraint (fin digest, digest >= 224, digest <= 512)
 
 sha3 : {n} (fin n) => [n] -> [digest]
-sha3 M =
-  take`{digest} (Keccak `{r=1600-(2*digest)} (M # 0b01))
+sha3 M = Keccak`{d=digest} (M # 0b01)

--- a/Primitive/Keyless/Hash/SHA3/SHA3_224.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3_224.cry
@@ -1,10 +1,9 @@
+/**
+ * Instantiation of SHA3-224.
+ *
+ * @copyright Galois Inc.
+ * @author Ajay Kumar Eeralla
+ */
 module Primitive::Keyless::Hash::SHA3::SHA3_224 =
-       Primitive::Keyless::Hash::SHA3::SHA3
-where
-
-type digest = 224
-
-
-
-
-
+    Primitive::Keyless::Hash::SHA3::SHA3 where
+        type digest = 224

--- a/Primitive/Keyless/Hash/SHA3/SHA3_256.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3_256.cry
@@ -1,6 +1,9 @@
+/**
+ * Instantiation of SHA3-256.
+ *
+ * @copyright Galois Inc.
+ * @author Ajay Kumar Eeralla
+ */
 module Primitive::Keyless::Hash::SHA3::SHA3_256 =
-       Primitive::Keyless::Hash::SHA3::SHA3
-where
-  type digest = 256
-
-
+    Primitive::Keyless::Hash::SHA3::SHA3 where
+        type digest = 256

--- a/Primitive/Keyless/Hash/SHA3/SHA3_384.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3_384.cry
@@ -1,8 +1,9 @@
+/**
+ * Instantiation of SHA3-384.
+ *
+ * @copyright Galois Inc.
+ * @author Ajay Kumar Eeralla
+ */
 module Primitive::Keyless::Hash::SHA3::SHA3_384 =
-       Primitive::Keyless::Hash::SHA3::SHA3
-where
-
-type digest = 384
-
-
-
+    Primitive::Keyless::Hash::SHA3::SHA3 where
+        type digest = 384

--- a/Primitive/Keyless/Hash/SHA3/SHA3_512.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3_512.cry
@@ -1,7 +1,9 @@
+/**
+ * Instantiation of SHA3-512.
+ *
+ * @copyright Galois Inc.
+ * @author Ajay Kumar Eeralla
+ */
 module Primitive::Keyless::Hash::SHA3::SHA3_512 =
-       Primitive::Keyless::Hash::SHA3::SHA3
-  where
-
-type digest = 512
-
-
+    Primitive::Keyless::Hash::SHA3::SHA3 where
+        type digest = 512

--- a/Primitive/Keyless/Hash/SHA3/Tests.cry
+++ b/Primitive/Keyless/Hash/SHA3/Tests.cry
@@ -1,26 +1,54 @@
+/*
+ * Tests of the SHA3 hash functions.
+ *
+ * Test vectors drawn from the NIST Cryptographic Standards and Guidelines
+ * example values.
+ * https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values
+ *
+ * @copyright Galois Inc.
+ * @author Ajay Kumar Eeralla
+ * @editor Iavor Diatchki <diatchki@galois.com>
+ * @editor Marcella Hastings <marcella@galois.com>
+ */
 module Primitive::Keyless::Hash::SHA3::Tests where
 
 import Primitive::Keyless::Hash::utils
 
-// Test vectors from
-// https://csrc.nist.gov/projects/cryptographic-standards-and-guidelines/example-values#aHashing
-
-
 submodule SHA3_224 where
   import Primitive::Keyless::Hash::SHA3::SHA3_224
 
+  /*
+   * ```repl
+   * :prove t1
+   * ```
+   */
   property t1 = join (toBytes (sha3 [])) ==
     0x6b4e03423667dbb73b6e15454f0eb1abd4597f9a1b078e3f5b5a6bc7
 
+  /*
+   * ```repl
+   * :prove t2
+   * ```
+   */
   property t2 = join (toBytes (sha3 0b11001)) ==
     0xffbad5da96bad71789330206dc6768ecaeb1b32dca6b3301489674ab
 
   msg1600 : [1600]
   msg1600 = join [ 0b11000101 | _ <- zero : [200] ]
 
+  /*
+   * ```repl
+   * :prove t3
+   * ```
+   */
   property t3 = join (toBytes (sha3 msg1600)) ==
     0x9376816aba503f72f96ce7eb65ac095deee3be4bf9bbc2a1cb7e11e0
 
+  /*
+   * ```repl
+   * :prove t4
+   * ```
+   */
   property t4 = join (toBytes (sha3 (msg1600 # 0b11000))) ==
     0x22d2f7bb0b173fd8c19686f9173166e3ee62738047d7eadd69efb228
 
@@ -28,12 +56,27 @@ submodule SHA3_224 where
 submodule SHA3_256 where
   import Primitive::Keyless::Hash::SHA3::SHA3_256
 
+  /*
+   * ```repl
+   * :prove t1
+   * ```
+   */
   property t1 = join (toBytes (sha3 [])) ==
     0xa7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a
 
+  /*
+   * ```repl
+   * :prove t2
+   * ```
+   */
   property t2 = join (toBytes (sha3 0b11001)) ==
     0x7b0047cf5a456882363cbf0fb05322cf65f4b7059a46365e830132e3b5d957af
 
+  /*
+   * ```repl
+   * :prove t3
+   * ```
+   */
   property t3 = join (toBytes (sha3 0b110010100001101011011110100110)) ==
       0xc8242fef409e5ae9d1f1c857ae4dc624b92b19809f62aa8c07411c54a078b1d0
 
@@ -41,9 +84,19 @@ submodule SHA3_256 where
 submodule SHA3_384 where
   import Primitive::Keyless::Hash::SHA3::SHA3_384
 
+  /*
+   * ```repl
+   * :prove t1
+   * ```
+   */
   property t1 = join (toBytes (sha3 [])) ==
     0x0c63a75b845e4f7d01107d852e4c2485c51a50aaaa94fc61995e71bbee983a2ac3713831264adb47fb6bd1e058d5f004
 
+  /*
+   * ```repl
+   * :prove t2
+   * ```
+   */
   property t2 = join (toBytes (sha3 0b11001)) ==
    0x737c9b491885e9bf7428e792741a7bf8dca9653471c3e148473f2c236b6a0a6455eb1dce9f779b4b6b237fef171b1c64
 
@@ -51,9 +104,19 @@ submodule SHA3_384 where
 submodule SHA3_512 where
   import Primitive::Keyless::Hash::SHA3::SHA3_512
 
+  /*
+   * ```repl
+   * :prove t1
+   * ```
+   */
   property t1 = join (toBytes (sha3 [])) ==
     0xa69f73cca23a9ac5c8b567dc185a756e97c982164fe25859e0d1dcc1475c80a615b2123af1f5f94c11e3e9402c3ac558f500199d95b6d3e301758586281dcd26
 
+  /*
+   * ```repl
+   * :prove t2
+   * ```
+   */
   property t2 = join (toBytes (sha3 0b11001)) ==
     0xa13e01494114c09800622a70288c432121ce70039d753cadd2e006e4d961cb27544c1481e5814bdceb53be6733d5e099795e5e81918addb058e22a9f24883f37
 

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
@@ -1,11 +1,12 @@
 module Primitive::Keyless::Hash::SHAKE::SHAKE128 where
-import Primitive::Keyless::Hash::keccak
+import Primitive::Keyless::Hash::keccak where
+    type b = 1600
+    type nr = 24
 import Primitive::Keyless::Hash::utils (toBytes)
 
-type total = 1600
 type secBits = 128
 
-shake128 M = Keccak `{r = total - 2 * secBits, c = 2 * secBits } (M # 0b1111)
+shake128 M = Keccak `{r = 1600 - 2 * secBits } (M # 0b1111)
 
 property k1 = join (toBytes (take`{512} (shake128 []))) == join [ 0x7f9c2ba4e88f827d616045507605853e
                                                              , 0xd73b8093f6efbc88eb1a6eacfa66ef26

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
@@ -26,10 +26,12 @@ import Primitive::Keyless::Hash::utils (toBytes)
  * SHAKE128 extendable-output function.
  * [FIPS-202] Section 6.2.
  *
+ * This supports any output length `d`, including infinite length.
+ *
  * Note that the specification of `c` is above, in the instantiation of the
  * `keccak` module.
  */
-shake128 : {m, d} (fin m, fin d) => [m] -> [d]
+shake128 : {d, m} (fin m) => [m] -> [d]
 shake128 M = Keccak (M # 0b1111)
 
 /**

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
@@ -35,12 +35,12 @@ shake128 : {d, m} (fin m) => [m] -> [d]
 shake128 M = Keccak (M # 0b1111)
 
 /**
- * Example showing how to call shake128 using an explicit type parameter.
+ * Example showing how to call shake128 using a type parameter.
  * ```repl
  * :prove k1
  * ```
  */
-property k1 = join (toBytes (shake128`{d=512} [])) == expected_result where
+property k1 = join (toBytes (shake128`{512} [])) == expected_result where
     expected_result = join [
         0x7f9c2ba4e88f827d616045507605853e,
         0xd73b8093f6efbc88eb1a6eacfa66ef26,
@@ -80,7 +80,7 @@ property k3 = join (toBytes (shake128 0b11)) == expected_result where
  * :prove k4
  * ```
  */
-property k4 = join (toBytes (shake128 (reverse 0b110))) == expected_result where
+property k4 = join (toBytes (shake128`{d=512} (reverse 0b110))) == expected_result where
     expected_result = join [
         0x178afb3be00c33b682f0c920520699e3,
         0xb7e4c360274fd8b41cdeaa8d3c675bdc,

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
@@ -2,34 +2,67 @@ module Primitive::Keyless::Hash::SHAKE::SHAKE128 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
     type nr = 24
+    // The capacity is double the security level, so this provides a security
+    // level of 128 (as the name suggests).
+    type c = 256
 import Primitive::Keyless::Hash::utils (toBytes)
 
-type secBits = 128
+shake128 : {m, d} (fin m, fin d) => [m] -> [d]
+shake128 M = Keccak (M # 0b1111)
 
-shake128 M = Keccak `{r = 1600 - 2 * secBits } (M # 0b1111)
+/**
+ * Example showing how to call shake128 using an explicit type parameter.
+ * ```repl
+ * :prove k1
+ * ```
+ */
+property k1 = join (toBytes (shake128`{d=512} [])) == expected_result where
+    expected_result = join [
+        0x7f9c2ba4e88f827d616045507605853e,
+        0xd73b8093f6efbc88eb1a6eacfa66ef26,
+        0x3cb1eea988004b93103cfb0aeefd2a68,
+        0x6e01fa4a58e8a3639ca8a1e3f9ae57e2
+    ]
 
-property k1 = join (toBytes (take`{512} (shake128 []))) == join [ 0x7f9c2ba4e88f827d616045507605853e
-                                                             , 0xd73b8093f6efbc88eb1a6eacfa66ef26
-                                                             , 0x3cb1eea988004b93103cfb0aeefd2a68
-                                                             , 0x6e01fa4a58e8a3639ca8a1e3f9ae57e2
-                                                             ]
+/**
+ * Example showing how to call shake128 using a type annotation.
+ * ```repl
+ * :prove k2
+ * ```
+ */
+property k2 = join (toBytes (shake128 0b0 : [512])) == expected_result where
+    expected_result = join [
+        0xe78b86559a9ccdc72288bf7bcf8e11d5,
+        0x74543a2922978913a02be149e89d03ca,
+        0xe63d2c36e2cf6906791b187d7e371d4f,
+        0x21ebe59dcfc249a510b82255a18250dd
+    ]
+/**
+ * Example showing how to call shake128 using an implicit output type.
+ * ```repl
+ * :prove k3
+ * ```
+ */
+property k3 = join (toBytes (shake128 0b11)) == expected_result where
+    expected_result = join [
+        0xf6b6c4093f0a2ceba61b9f2c2fea2ca2,
+        0x38ce9005edcd588c380405070532ddd0,
+        0x0cbd3a3a7448017d874c52c9e383fa3d,
+        0xb1c184e023181fcc8550f53ac92feca5
+    ]
 
-property k2 = join (toBytes (take`{512} (shake128 0b0))) == join [ 0xe78b86559a9ccdc72288bf7bcf8e11d5
-                                                              , 0x74543a2922978913a02be149e89d03ca
-                                                              , 0xe63d2c36e2cf6906791b187d7e371d4f
-                                                              , 0x21ebe59dcfc249a510b82255a18250dd
-                                                              ]
-property k3 = join (toBytes (take`{512} (shake128 0b11))) == join [ 0xf6b6c4093f0a2ceba61b9f2c2fea2ca2
-                                                               , 0x38ce9005edcd588c380405070532ddd0
-                                                               , 0x0cbd3a3a7448017d874c52c9e383fa3d
-                                                               , 0xb1c184e023181fcc8550f53ac92feca5
-                                                               ]
-
-property k4 = join (toBytes (take`{512} (shake128 (reverse 0b110)))) == join [ 0x178afb3be00c33b682f0c920520699e3
-                                                                          , 0xb7e4c360274fd8b41cdeaa8d3c675bdc
-                                                                          , 0x079be55d4513e7479aa903169430f0a0
-                                                                          , 0xbf60169becd0ff9ff3ff6be24bc6fd83
-                                                                          ]
+/**
+ * ```repl
+ * :prove k4
+ * ```
+ */
+property k4 = join (toBytes (shake128 (reverse 0b110))) == expected_result where
+    expected_result = join [
+        0x178afb3be00c33b682f0c920520699e3,
+        0xb7e4c360274fd8b41cdeaa8d3c675bdc,
+        0x079be55d4513e7479aa903169430f0a0,
+        0xbf60169becd0ff9ff3ff6be24bc6fd83
+    ]
 
 
 

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE128.cry
@@ -1,3 +1,18 @@
+/*
+ * Instantiation of SHAKE128, a SHA-3 extendable-output function, as specified
+ * in [FIPS-202].
+ *
+ * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
+ *     Permutation-Based Hash and Extendable-Output Functions. (Department of
+ *     Commerce, Washington, D.C.), Federal Information Processing Standards
+ *     Publication (FIPS) NIST FIPS 202. August 2015.
+ *     @see https://dx.doi.org/10.6028/NIST.FIPS.202
+ *
+ * @copyright Galois, Inc.
+ * @author Ajay Kumar Eeralla
+ * @editor Marcella Hastings <marcella@galois.com>
+ *
+ */
 module Primitive::Keyless::Hash::SHAKE::SHAKE128 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
@@ -7,6 +22,13 @@ import Primitive::Keyless::Hash::keccak where
     type c = 256
 import Primitive::Keyless::Hash::utils (toBytes)
 
+/**
+ * SHAKE128 extendable-output function.
+ * [FIPS-202] Section 6.2.
+ *
+ * Note that the specification of `c` is above, in the instantiation of the
+ * `keccak` module.
+ */
 shake128 : {m, d} (fin m, fin d) => [m] -> [d]
 shake128 M = Keccak (M # 0b1111)
 

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -1,3 +1,18 @@
+/*
+ * Instantiation of SHAKE256, a SHA-3 extendable-output function, as specified
+ * in [FIPS-202].
+ *
+ * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
+ *     Permutation-Based Hash and Extendable-Output Functions. (Department of
+ *     Commerce, Washington, D.C.), Federal Information Processing Standards
+ *     Publication (FIPS) NIST FIPS 202. August 2015.
+ *     @see https://dx.doi.org/10.6028/NIST.FIPS.202
+ *
+ * @copyright Galois, Inc.
+ * @author Ajay Kumar Eeralla
+ * @editor Marcella Hastings <marcella@galois.com>
+ *
+ */
 module Primitive::Keyless::Hash::SHAKE::SHAKE256 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
@@ -7,8 +22,13 @@ import Primitive::Keyless::Hash::keccak where
     type c = 512
 import Primitive::Keyless::Hash::utils (toBytes)
 
-type secBits = 256
-
+/**
+ * SHAKE256 extendable-output function.
+ * [FIPS-202] Section 6.2.
+ *
+ * Note that the specification of `c` is above, in the instantiation of the
+ * `keccak` module.
+ */
 shake256: {m, d} (fin m, fin d) => [m] -> [d]
 shake256 M = Keccak (M # 0b1111)
 
@@ -62,4 +82,4 @@ property k8 = join (toBytes (shake256 (reverse 0b110))) == expected_result where
         0xbddbe2cbd3a9a3ba3914da88e5853e70,
         0x83630e6d51d7a009017d8176c3067329,
         0xbec8e5f65591d65c5894c40132f1a2ab
-    ]
+                                                                             ]

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -12,6 +12,11 @@ type secBits = 256
 shake256: {m, d} (fin m, fin d) => [m] -> [d]
 shake256 M = Keccak (M # 0b1111)
 
+/*
+ * ```repl
+ * :prove k5
+ * ```
+ */
 property k5 = join (toBytes (shake256`{d=512} [])) == expected_result where
     expected_result = join [
         0x46b9dd2b0ba88d13233b3feb743eeb24,
@@ -20,6 +25,11 @@ property k5 = join (toBytes (shake256`{d=512} [])) == expected_result where
         0xfc821c49479ab48640292eacb3b7c4be
     ]
 
+/*
+ * ```repl
+ * :prove k6
+ * ```
+ */
 property k6 = join (toBytes (shake256 0b0)) == expected_result where
     expected_result = join [
         0x1e20b13f3bdb730d286913335c092bce,
@@ -28,6 +38,11 @@ property k6 = join (toBytes (shake256 0b0)) == expected_result where
         0x55d30410d71b8e275a676545600f1c35
     ]
 
+/*
+ * ```repl
+ * :prove k7
+ * ```
+ */
 property k7 = join (toBytes (shake256 0b11 : [512])) == expected_result where
     expected_result = join [
         0x4f86b0eb85f7a9f6dc38b622706948ad,
@@ -36,6 +51,11 @@ property k7 = join (toBytes (shake256 0b11 : [512])) == expected_result where
         0x7c98f3948e6b7959a9b8950ffd6345d5
     ]
 
+/*
+ * ```repl
+ * :prove k8
+ * ```
+ */
 property k8 = join (toBytes (shake256 (reverse 0b110))) == expected_result where
     expected_result = join [
         0x27b5f40b3645215e370472ebb06817ae,

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -26,10 +26,12 @@ import Primitive::Keyless::Hash::utils (toBytes)
  * SHAKE256 extendable-output function.
  * [FIPS-202] Section 6.2.
  *
+ * This supports any output length `d`, including infinite length.
+ *
  * Note that the specification of `c` is above, in the instantiation of the
  * `keccak` module.
  */
-shake256: {m, d} (fin m, fin d) => [m] -> [d]
+shake256: {d, m} (fin m) => [m] -> [d]
 shake256 M = Keccak (M # 0b1111)
 
 /*

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -2,32 +2,44 @@ module Primitive::Keyless::Hash::SHAKE::SHAKE256 where
 import Primitive::Keyless::Hash::keccak where
     type b = 1600
     type nr = 24
+    // The capacity is double the security level, so this provides a security
+    // level of 256 (as the name suggests).
+    type c = 512
 import Primitive::Keyless::Hash::utils (toBytes)
 
 type secBits = 256
 
-shake256 M = Keccak `{r = 1600 - 2 * secBits} (M # 0b1111)
+shake256: {m, d} (fin m, fin d) => [m] -> [d]
+shake256 M = Keccak (M # 0b1111)
 
-property k5 = join (toBytes (take`{512} (shake256 []))) == join [ 0x46b9dd2b0ba88d13233b3feb743eeb24
-                                                                , 0x3fcd52ea62b81b82b50c27646ed5762f
-                                                                , 0xd75dc4ddd8c0f200cb05019d67b592f6
-                                                                , 0xfc821c49479ab48640292eacb3b7c4be
-                                                                ]
+property k5 = join (toBytes (shake256`{d=512} [])) == expected_result where
+    expected_result = join [
+        0x46b9dd2b0ba88d13233b3feb743eeb24,
+        0x3fcd52ea62b81b82b50c27646ed5762f,
+        0xd75dc4ddd8c0f200cb05019d67b592f6,
+        0xfc821c49479ab48640292eacb3b7c4be
+    ]
 
-property k6 = join (toBytes (take`{512} (shake256 0b0))) == join [ 0x1e20b13f3bdb730d286913335c092bce
-                                                                 , 0xc0eb1aff2798c05736faa93bd665807a
-                                                                 , 0x48ed7652aefd600427e9f797d647b9b3
-                                                                 , 0x55d30410d71b8e275a676545600f1c35
-                                                                 ]
+property k6 = join (toBytes (shake256 0b0)) == expected_result where
+    expected_result = join [
+        0x1e20b13f3bdb730d286913335c092bce,
+        0xc0eb1aff2798c05736faa93bd665807a,
+        0x48ed7652aefd600427e9f797d647b9b3,
+        0x55d30410d71b8e275a676545600f1c35
+    ]
 
-property k7 = join (toBytes (take`{512} (shake256 0b11))) == join [ 0x4f86b0eb85f7a9f6dc38b622706948ad
-                                                                  , 0xb2beb6dd6911b5e9d865fd1f9667b5c0
-                                                                  , 0x2a0dbb39c488b040a18ff3885f04ef95
-                                                                  , 0x7c98f3948e6b7959a9b8950ffd6345d5
-                                                                  ]
+property k7 = join (toBytes (shake256 0b11 : [512])) == expected_result where
+    expected_result = join [
+        0x4f86b0eb85f7a9f6dc38b622706948ad,
+        0xb2beb6dd6911b5e9d865fd1f9667b5c0,
+        0x2a0dbb39c488b040a18ff3885f04ef95,
+        0x7c98f3948e6b7959a9b8950ffd6345d5
+    ]
 
-property k8 = join (toBytes (take`{512} (shake256 (reverse 0b110)))) == join [ 0x27b5f40b3645215e370472ebb06817ae
-                                                                             , 0xbddbe2cbd3a9a3ba3914da88e5853e70
-                                                                             , 0x83630e6d51d7a009017d8176c3067329
-                                                                             , 0xbec8e5f65591d65c5894c40132f1a2ab
-                                                                             ]
+property k8 = join (toBytes (shake256 (reverse 0b110))) == expected_result where
+    expected_result = join [
+        0x27b5f40b3645215e370472ebb06817ae,
+        0xbddbe2cbd3a9a3ba3914da88e5853e70,
+        0x83630e6d51d7a009017d8176c3067329,
+        0xbec8e5f65591d65c5894c40132f1a2ab
+    ]

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -39,7 +39,7 @@ shake256 M = Keccak (M # 0b1111)
  * :prove k5
  * ```
  */
-property k5 = join (toBytes (shake256`{d=512} [])) == expected_result where
+property k5 = join (toBytes (shake256`{512} [])) == expected_result where
     expected_result = join [
         0x46b9dd2b0ba88d13233b3feb743eeb24,
         0x3fcd52ea62b81b82b50c27646ed5762f,
@@ -78,7 +78,7 @@ property k7 = join (toBytes (shake256 0b11 : [512])) == expected_result where
  * :prove k8
  * ```
  */
-property k8 = join (toBytes (shake256 (reverse 0b110))) == expected_result where
+property k8 = join (toBytes (shake256`{d=512} (reverse 0b110))) == expected_result where
     expected_result = join [
         0x27b5f40b3645215e370472ebb06817ae,
         0xbddbe2cbd3a9a3ba3914da88e5853e70,

--- a/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
+++ b/Primitive/Keyless/Hash/SHAKE/SHAKE256.cry
@@ -1,11 +1,12 @@
 module Primitive::Keyless::Hash::SHAKE::SHAKE256 where
-import Primitive::Keyless::Hash::keccak
+import Primitive::Keyless::Hash::keccak where
+    type b = 1600
+    type nr = 24
 import Primitive::Keyless::Hash::utils (toBytes)
 
-type total = 1600
 type secBits = 256
 
-shake256 M = Keccak `{r = total - 2 * secBits, c = 2 * secBits } (M # 0b1111)
+shake256 M = Keccak `{r = 1600 - 2 * secBits} (M # 0b1111)
 
 property k5 = join (toBytes (take`{512} (shake256 []))) == join [ 0x46b9dd2b0ba88d13233b3feb743eeb24
                                                                 , 0x3fcd52ea62b81b82b50c27646ed5762f

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -1,9 +1,19 @@
-/*
- * Copyright (c) 2013 David Lazar <lazard@galois.com>
+/**
+ * Specification of the Keccak (SHA-3) hash function
+ *
+ *
+ *
+ * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
+ *     Permutation-Based Hash and Extendable-Output Functions. (Department of
+ *     Commerce, Washington, D.C.), Federal Information Processing Standards
+ *     Publication (FIPS) NIST FIPS 202. August 2015.
+ *     @see https://dx.doi.org/10.6028/NIST.FIPS.202
+ *
+ * @copyright Galois, Inc. 2013 - 2024
+ * @author David Lazar <lazard@galois.com>
+ * @author Marcella Hastings <marcella@galois.com>
+ *
  */
-
-// Specification of the Keccak (SHA-3) hash function
-// Author: David Lazar
 module Primitive::Keyless::Hash::keccak where
 
 Keccak : {r, c, m}
@@ -37,6 +47,11 @@ Keccak_f A0 = rounds ! 0
 Round : {w} (fin w) => [5][5][w] -> [5][5][w] -> [5][5][w]
 Round RC A = ι RC (χ (π (ρ (θ A))))
 
+/**
+ * One of the step mappings that's part of a round of Keccak-p.
+ *
+ * [FIPS-202] Section 3.2.1.
+ */
 θ : {w} (fin w) => [5][5][w] -> [5][5][w]
 θ A = A'
   where
@@ -47,6 +62,11 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
         ]
     A' = [ [ a ^ (D @ x) | a <- A @ x ] | (x:[8]) <- [0 .. 4] ]
 
+/**
+ * One of the step mappings that's part of a round of Keccak-p.
+ *
+ * [FIPS-202] Section 3.2.2.
+ */
 ρ : {w} (fin w) => [5][5][w] -> [5][5][w]
 ρ A = groupBy`{5} [ a <<< r | a <- join A | (r:[8]) <- R ]
   where R = [00, 36, 03, 41, 18,
@@ -55,17 +75,32 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
              28, 55, 25, 21, 56,
              27, 20, 39, 08, 14]
 
+/**
+ * One of the step mappings that's part of a round of Keccak-p.
+ *
+ * [FIPS-202] Section 3.2.3.
+ */
 π : {w} (fin w) => [5][5][w] -> [5][5][w]
 π A = groupBy`{5} [ A @ ((x + 3*y) % 5) @ x
                   | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
                   ]
 
+/**
+ * One of the step mappings that's part of a round of Keccak-p.
+ *
+ * [FIPS-202] Section 3.2.4.
+ */
 χ : {w} (fin w) => [5][5][w] -> [5][5][w]
 χ A = groupBy`{5} [ (A @ x @ y) ^ (~ A @ ((x + 1) % 5) @ y
                                   && A @ ((x + 2) % 5) @ y)
                   | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
                   ]
 
+/**
+ * One of the step mappings that's part of a round of Keccak-p.
+ *
+ * [FIPS-202] Section 3.2.5.
+ */
 ι : {w} (fin w) => [5][5][w] -> [5][5][w] -> [5][5][w]
 ι RC A = A ^ RC
 

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -40,8 +40,11 @@ parameter
      * For the standardized SHA3 parameter sets, only `Keccak-f` is required.
      * [FIPS-202] Section 3.4.
      *
-     * @design we intend to refactor this and the RC functions to allow the
-     * fully generic Keccak-p implementation.
+     * @design Marcella Hastings <marcella@galois.com>. I intend to refactor
+     * this and the RC functions to allow the fully generic `Keccak-p`
+     * implementation; right now it's restricted to this specific function of
+     * `b`, as is required by `Keccak-f`; this is enough to support the
+     * standardized SHA3 functions but not the fully generic specification.
      */
     type nr : #
     type constraint (fin nr, nr > 0, nr == 12 + 2 * (lg2 ( b / 25)))
@@ -62,10 +65,12 @@ parameter
  * [FIPS-202] Section 4, Algorithm 8; instantiated as in Section 5.2.
  */
 Keccak : {d, m} (fin m) => [m] -> [d]
-Keccak M = take`{front=d, back=inf} (extend (Ss ! 0)) where
+Keccak M = digest where
     // Step 1.
     P = M # pad `{x = r, m = m}
-    // Step 2.
+    // Step 2. Note than `len(P)` is not necessarily _exactly_ `m + 2`; that's
+    // the minimum length of `P`. We use round-up division `/^` to compute the
+    // correct number of `r`-length strings.
     type n = (m + 2) /^ r
     // Step 3. `c` is a parameter for this module.
     // Step 4. Ps = P_0, ..., P_{n-1}.
@@ -74,9 +79,12 @@ Keccak M = take`{front=d, back=inf} (extend (Ss ! 0)) where
     S = zero : [b]
     // Step 6. We create a list `Ss` instead of overwriting the variable `S`.
     Ss = [S] # [Keccak_f (S' ^ (Pi # (zero : [c]))) | Pi <- Ps | S' <- Ss]
-    // Step 7 - 9. This step is sometimes known as "squeeze".
+    // Steps 7 - 10. This step is sometimes known as "squeeze".
+    // The truncation in Step 8 is handled here with `take`{r}`
+    // The truncation in Step 9 is below with `take`{front=d, back=inf}`.
     extend : [b] -> [inf]
     extend Z = (take`{r} Z) # extend (Keccak_f Z)
+    digest = take`{front=d, back=inf} (extend (Ss ! 0))
 
 private
     /**

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -3,7 +3,7 @@
  *
  *
  *
- * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
+ * [FIPS-02]: National Institute of Standards and Technology. SHA-3 Standard:
  *     Permutation-Based Hash and Extendable-Output Functions. (Department of
  *     Commerce, Washington, D.C.), Federal Information Processing Standards
  *     Publication (FIPS) NIST FIPS 202. August 2015.
@@ -16,22 +16,54 @@
  */
 module Primitive::Keyless::Hash::keccak where
 
-Keccak : {r, c, m}
-    ( fin r, fin c, fin m
-    , r >= 1
-    , (r + c) % 25 == 0
-    , 64 >= (r + c) / 25
-    ) => [m] -> [inf]
-Keccak M = squeeze `{r = r} (absorb `{w = (r + c) / 25} Ps)
+parameter
+    /**
+     * Width: the fixed length of the strings that are permuted.
+     *
+     * This restricts `b` to the valid permutation widths:
+     * 25, 50, 100, 200, 400, 800, and 1600.
+     * In particular, the final constraint enforces that `b / 25` is exactly a
+     * power of two, so 0 and any other multiple of 25 is invalid.
+     *
+     * [FIPS-202] Section 3 (intro).
+     */
+    type b : #
+    type constraint (fin b, b % 25 == 0, b <= 1600, (2 ^^ (lg2 (b / 25))) * 25 == b)
+
+    /**
+     * Rounds: the number of iterations of an internal transformation.
+     *
+     * [FIPS-202] Section 3 (intro).
+     */
+    type nr : #
+    type constraint (fin nr, nr > 0, nr == 12 + 2 * (lg2 ( b / 25)))
+
+/**
+ * State width of the permuatation.
+ * [FIPS-202] Section 3.1.
+ */
+type w = b / 25
+
+/**
+ * TODO: Figure out what this represents for the docs.
+ * [FIPS-202] Section 3.1.
+ */
+type ell = lg2 w
+
+type State = [5][5][w]
+
+Keccak : {r, m}
+    ( fin r, fin m, b >= r, r >= 1) => [m] -> [inf]
+Keccak M = squeeze `{r = r} (absorb Ps)
     where Ps = pad `{r = r} M
 
-squeeze : {r, w} (fin r, fin w, 64 >= w, r >= 0, 25 * w >= r) => [5][5][w] -> [inf]
+squeeze : {r} (fin r, r >= 0, b >= r) => State -> [inf]
 squeeze A = take`{r} (flatten A) # squeeze`{r = r} (Keccak_f A)
 
-absorb : {r, w, n} (fin r, fin w, fin n, 64 >= w, 25 * w >= r) => [n][r] -> [5][5][w]
+absorb : {r, n} (fin r, fin n, b >= r) => [n][r] -> State
 absorb Ps = as ! 0
     where
-        as = [zero] # [ Keccak_f `{w = w} (s ^ (unflatten p)) | s <- as | p <- Ps ]
+        as = [zero] # [ Keccak_f (s ^ (unflatten p)) | s <- as | p <- Ps ]
 
 pad : {r, m}
     ( fin r, fin m
@@ -39,12 +71,12 @@ pad : {r, m}
     ) => [m] -> [(m + 2) /^ r][r]
 pad M = split (M # [True] # zero # [True])
 
-Keccak_f : {w} (fin w, 64 >= w) => [5][5][w] -> [5][5][w]
+Keccak_f : State -> State
 Keccak_f A0 = rounds ! 0
     where
-        rounds = [A0] # [ Round RC A | RC <- RCs`{w = w} | A <- rounds ]
+        rounds = [A0] # [ Round RC A | RC <- RCs | A <- rounds ]
 
-Round : {w} (fin w) => [5][5][w] -> [5][5][w] -> [5][5][w]
+Round : State -> State -> State
 Round RC A = ι RC (χ (π (ρ (θ A))))
 
 /**
@@ -52,7 +84,7 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  *
  * [FIPS-202] Section 3.2.1.
  */
-θ : {w} (fin w) => [5][5][w] -> [5][5][w]
+θ : State -> State
 θ A = A' where
     C = [ xor a | a <- A ]
     D = [ C @ x ^ (C @ y <<< 1)
@@ -68,7 +100,7 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  *
  * [FIPS-202] Section 3.2.2.
  */
-ρ : {w} (fin w) => [5][5][w] -> [5][5][w]
+ρ : State -> State
 ρ A = groupBy`{5} [ a <<< r | a <- join A | (r:[8]) <- R ]
     where
         R = [
@@ -84,7 +116,7 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  *
  * [FIPS-202] Section 3.2.3.
  */
-π : {w} (fin w) => [5][5][w] -> [5][5][w]
+π : State -> State
 π A = groupBy`{5} [ A @ ((x + 3*y) % 5) @ x
                   | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
                   ]
@@ -94,7 +126,7 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  *
  * [FIPS-202] Section 3.2.4.
  */
-χ : {w} (fin w) => [5][5][w] -> [5][5][w]
+χ : State -> State
 χ A = groupBy`{5} [ (A @ x @ y) ^ (~ A @ ((x + 1) % 5) @ y
                                   && A @ ((x + 2) % 5) @ y)
                   | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
@@ -105,10 +137,10 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  *
  * [FIPS-202] Section 3.2.5.
  */
-ι : {w} (fin w) => [5][5][w] -> [5][5][w] -> [5][5][w]
+ι : State -> State -> State
 ι RC A = A ^ RC
 
-RCs : {w, n} (fin w, fin n, 24 >= n, n == 12 + 2 * (lg2 w)) => [n][5][5][w]
+RCs : {n} (fin n, 24 >= n, n == 12 + 2 * ell) => [n]State
 RCs = take`{n} [ [[take`{w} RC] # zero] # zero | RC <- RCs64 ]
 
 RCs64 : [24][64]
@@ -127,13 +159,13 @@ RCs64 = join (transpose [
     [0x000000008000000A, 0x8000000080008008]
 ])
 
-unflatten : {r, w} (fin w, 25*w >= r) => [r] -> [5][5][w]
+unflatten : {r} (b >= r) => [r] -> State
 unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse (p # zero)))))
 
-flatten : {w} (fin w) => [5][5][w] -> [5 * 5 * w]
+flatten : State -> [5 * 5 * w]
 flatten A = reverse (join (reverse (join (transpose A))))
 
-xor : {a, b} (fin a) => [a][b] -> [b]
+xor : {a, c} (fin a) => [a][c] -> [c]
 xor xs = xors ! 0
     where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
 
@@ -147,12 +179,23 @@ lfsr = [ p!0 | p <- ps ]
     ps = [0x01] # [ pmod (pmult p 0b10) m | p <- ps ]
     m = <| x^^8 + x^^6 + x^^5 + x^^4 + 1 |>
 
-/* See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2 */
+/**
+ * See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2
+ * ```repl
+ * :prove unflatten_correct`{w=1600}
+ * ```
+ * TODO: These hardcoded 64s might be wrong.
+ */
 property unflatten_correct x y z p =
     x < 5 ==> y < 5 ==> z < (64:[12]) ==>
-    p@((5*y + x)*64 + z) == unflatten`{1600,64} p @ x @ y ! z
+    p@((5*y + x)*64 + z) == unflatten p @ x @ y ! z
 
+/**
+ * ```repl
+ * :prove flatten_correct`{w=1600}
+ * ```
+ */
 property flatten_correct s =
-    unflatten`{1600,64} (flatten`{64} s) == s
+    unflatten (flatten s) == s
 
 

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -38,16 +38,29 @@ parameter
     type nr : #
     type constraint (fin nr, nr > 0, nr == 12 + 2 * (lg2 ( b / 25)))
 
-Keccak : {r, m}
-    ( fin r, fin m, b >= r, r >= 1) => [m] -> [inf]
-Keccak M = extend (Ss ! 0) where
+    /**
+     * Capacity parameter for the sponge construction.
+     * [FIPS-202] Section 4.
+     */
+    type c : #
+    type constraint (fin c, c < b, c > 0)
+
+/**
+ * Keccak family of sponge functions.
+ *
+ * At this time, the implementation is not generic with respect to the sponge
+ * construction.
+ */
+Keccak : {m, d}
+    (fin m, fin d) => [m] -> [d]
+Keccak M = take`{d} (extend (Ss ! 0)) where
     // Step 1.
     P = M # pad `{x = r, m = m}
     // Step 2. We leave the type `n` implicit.
-    // Step k3.
-    type c = b - r
+    type n = (m + 2) /^ r
+    // Step 3. `c` is a parameter for this module.
     // Step 4. Ps = P_0, ..., P_{n-1}.
-    Ps = split P : [_][r]
+    Ps = split P : [n][r]
     // Step 5.
     S = zero : [b]
     // Step 6. We create a list `Ss` instead of overwriting the variable `S`.
@@ -57,6 +70,12 @@ Keccak M = extend (Ss ! 0) where
     extend Z = (take`{r} Z) # extend (Keccak_f Z)
 
 private
+    /**
+     * Rate parameter for the sponge construction.
+     * [FIPS-202] Section 4.
+     */
+    type r = b - c
+
     /**
      * State width of the permutation.
      * [FIPS-202] Section 3.1.
@@ -68,7 +87,24 @@ private
      * [FIPS-202] Section 3.1.
      */
     type ell = lg2 w
+
+    /**
+     * State for Keccak-p[b, nr], represented as an array.
+     * [FIPS-202] Section 3.1.
+     */
     type State = [5][5][w]
+
+    /**
+     * [FIPS-202] Section 3.1.2.
+     */
+    unflatten : [b] -> State
+    unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse p))))
+
+    /**
+     * [FIPS-202] Section 3.1.3.
+     */
+    flatten : State -> [5 * 5 * w]
+    flatten A = reverse (join (reverse (join (transpose A))))
 
     /**
      * Padding rule `pad10*1`.
@@ -146,6 +182,9 @@ private
     RCs : {n} (fin n, 24 >= n, n == 12 + 2 * ell) => [n]State
     RCs = take`{n} [ [[take`{w} RC] # zero] # zero | RC <- RCs64 ]
 
+    /**
+     * Hardcode the ??? values for b = 6400.
+     */
     RCs64 : [24][64]
     RCs64 = join (transpose [
         [0x0000000000000001, 0x000000008000808B],
@@ -178,13 +217,7 @@ private
     Round : State -> State -> State
     Round RC A = ι RC (χ (π (ρ (θ A))))
 
-    unflatten : {r} (b >= r) => [r] -> State
-    unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse (p # zero)))))
-
-    flatten : State -> [5 * 5 * w]
-    flatten A = reverse (join (reverse (join (transpose A))))
-
-    xor : {a, c} (fin a) => [a][c] -> [c]
+    xor : {a, l} (fin a) => [a][l] -> [l]
     xor xs = xors ! 0
         where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
 
@@ -201,21 +234,19 @@ property RC_correct i j =
 /**
  * See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2
  * ```repl
- * :prove unflatten_correct`{n=1600}
+ * :prove unflatten_correct
  * ```
- * TODO: These hardcoded 64s are wrong when `n =/= 1600`.
  */
-unflatten_correct : {n} (fin n, b >= n) => [12] -> [12] -> [12] -> [n] -> Bit
+unflatten_correct : [12] -> [12] -> [12] -> [b] -> Bit
 property unflatten_correct x y z p =
-    x < 5 ==> y < 5 ==> z < (64:[12]) ==>
-    p@((5*y + x)*64 + z) == unflatten p @ x @ y ! z
+    x < 5 ==> y < 5 ==> z < (`w:[12]) ==>
+    p@((5*y + x)*`w + z) == unflatten p @ x @ y ! z
 
 /**
  * ```repl
  * :prove flatten_correct
  * ```
  */
-property flatten_correct s =
-    unflatten (flatten s) == s
+property flatten_correct s = unflatten (flatten s) == s
 
 

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -17,32 +17,32 @@
 module Primitive::Keyless::Hash::keccak where
 
 Keccak : {r, c, m}
-  ( fin r, fin c, fin m
-  , r >= 1
-  , (r + c) % 25 == 0
-  , 64 >= (r + c) / 25
-  ) => [m] -> [inf]
+    ( fin r, fin c, fin m
+    , r >= 1
+    , (r + c) % 25 == 0
+    , 64 >= (r + c) / 25
+    ) => [m] -> [inf]
 Keccak M = squeeze `{r = r} (absorb `{w = (r + c) / 25} Ps)
-  where Ps = pad `{r = r} M
+    where Ps = pad `{r = r} M
 
 squeeze : {r, w} (fin r, fin w, 64 >= w, r >= 0, 25 * w >= r) => [5][5][w] -> [inf]
 squeeze A = take`{r} (flatten A) # squeeze`{r = r} (Keccak_f A)
 
 absorb : {r, w, n} (fin r, fin w, fin n, 64 >= w, 25 * w >= r) => [n][r] -> [5][5][w]
 absorb Ps = as ! 0
-  where
-    as = [zero] # [ Keccak_f `{w = w} (s ^ (unflatten p)) | s <- as | p <- Ps ]
+    where
+        as = [zero] # [ Keccak_f `{w = w} (s ^ (unflatten p)) | s <- as | p <- Ps ]
 
 pad : {r, m}
-  ( fin r, fin m
-  , r >= 1
-  ) => [m] -> [(m + 2) /^ r][r]
+    ( fin r, fin m
+    , r >= 1
+    ) => [m] -> [(m + 2) /^ r][r]
 pad M = split (M # [True] # zero # [True])
 
 Keccak_f : {w} (fin w, 64 >= w) => [5][5][w] -> [5][5][w]
 Keccak_f A0 = rounds ! 0
-  where
-    rounds = [A0] # [ Round RC A | RC <- RCs`{w = w} | A <- rounds ]
+    where
+        rounds = [A0] # [ Round RC A | RC <- RCs`{w = w} | A <- rounds ]
 
 Round : {w} (fin w) => [5][5][w] -> [5][5][w] -> [5][5][w]
 Round RC A = ι RC (χ (π (ρ (θ A))))
@@ -53,11 +53,12 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  * [FIPS-202] Section 3.2.1.
  */
 θ : {w} (fin w) => [5][5][w] -> [5][5][w]
-θ A = A'
-  where
+θ A = A' where
     C = [ xor a | a <- A ]
     D = [ C @ x ^ (C @ y <<< 1)
+        // In the spec, this is denoted `(x-1) mod 5` for 0 <= x < 5.
         | (x:[8]) <- [4,0,1,2,3]
+        // In the spec, this is denoted `(x+1) mod 5` for 0 <= x < 5.
         | (y:[8]) <- [1,2,3,4,0]
         ]
     A' = [ [ a ^ (D @ x) | a <- A @ x ] | (x:[8]) <- [0 .. 4] ]
@@ -69,11 +70,14 @@ Round RC A = ι RC (χ (π (ρ (θ A))))
  */
 ρ : {w} (fin w) => [5][5][w] -> [5][5][w]
 ρ A = groupBy`{5} [ a <<< r | a <- join A | (r:[8]) <- R ]
-  where R = [00, 36, 03, 41, 18,
-             01, 44, 10, 45, 02,
-             62, 06, 43, 15, 61,
-             28, 55, 25, 21, 56,
-             27, 20, 39, 08, 14]
+    where
+        R = [
+            00, 36, 03, 41, 18,
+            01, 44, 10, 45, 02,
+            62, 06, 43, 15, 61,
+            28, 55, 25, 21, 56,
+            27, 20, 39, 08, 14
+        ]
 
 /**
  * One of the step mappings that's part of a round of Keccak-p.
@@ -131,24 +135,24 @@ flatten A = reverse (join (reverse (join (transpose A))))
 
 xor : {a, b} (fin a) => [a][b] -> [b]
 xor xs = xors ! 0
-  where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
+    where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
 
 property RC_correct i j =
-  (i:[8]) < 24 ==> (j:[8]) < 7 ==> RCs64@i!(2^^j - 1) == lfsr@(j + 7*i)
+    (i:[8]) < 24 ==> (j:[8]) < 7 ==> RCs64@i!(2^^j - 1) == lfsr@(j + 7*i)
 
 lfsr : [inf]
 lfsr = [ p!0 | p <- ps ]
-  where
+    where
     /* powers of x modulo m */
     ps = [0x01] # [ pmod (pmult p 0b10) m | p <- ps ]
     m = <| x^^8 + x^^6 + x^^5 + x^^4 + 1 |>
 
 /* See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2 */
 property unflatten_correct x y z p =
-  x < 5 ==> y < 5 ==> z < (64:[12]) ==>
-  p@((5*y + x)*64 + z) == unflatten`{1600,64} p @ x @ y ! z
+    x < 5 ==> y < 5 ==> z < (64:[12]) ==>
+    p@((5*y + x)*64 + z) == unflatten`{1600,64} p @ x @ y ! z
 
 property flatten_correct s =
-  unflatten`{1600,64} (flatten`{64} s) == s
+    unflatten`{1600,64} (flatten`{64} s) == s
 
 

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -1,9 +1,9 @@
 /**
- * Specification of the Keccak (SHA-3) hash function
+ * Specification of the Keccak (SHA-3) hash function.
  *
  *
  *
- * [FIPS-02]: National Institute of Standards and Technology. SHA-3 Standard:
+ * [FIPS-202]: National Institute of Standards and Technology. SHA-3 Standard:
  *     Permutation-Based Hash and Extendable-Output Functions. (Department of
  *     Commerce, Washington, D.C.), Federal Information Processing Standards
  *     Publication (FIPS) NIST FIPS 202. August 2015.
@@ -23,7 +23,7 @@ parameter
      * This restricts `b` to the valid permutation widths:
      * 25, 50, 100, 200, 400, 800, and 1600.
      * In particular, the final constraint enforces that `b / 25` is exactly a
-     * power of two, so 0 and any other multiple of 25 is invalid.
+     * power of two, so 0 and any other multiple of 25 are invalid.
      *
      * [FIPS-202] Section 3 (intro).
      */
@@ -38,161 +38,162 @@ parameter
     type nr : #
     type constraint (fin nr, nr > 0, nr == 12 + 2 * (lg2 ( b / 25)))
 
-/**
- * State width of the permuatation.
- * [FIPS-202] Section 3.1.
- */
-type w = b / 25
-
-/**
- * TODO: Figure out what this represents for the docs.
- * [FIPS-202] Section 3.1.
- */
-type ell = lg2 w
-
-type State = [5][5][w]
-
 Keccak : {r, m}
     ( fin r, fin m, b >= r, r >= 1) => [m] -> [inf]
 Keccak M = squeeze `{r = r} (absorb Ps)
     where Ps = pad `{r = r} M
 
-squeeze : {r} (fin r, r >= 0, b >= r) => State -> [inf]
-squeeze A = take`{r} (flatten A) # squeeze`{r = r} (Keccak_f A)
+private
+    /**
+     * State width of the permutation.
+     * [FIPS-202] Section 3.1.
+     */
+    type w = b / 25
 
-absorb : {r, n} (fin r, fin n, b >= r) => [n][r] -> State
-absorb Ps = as ! 0
-    where
-        as = [zero] # [ Keccak_f (s ^ (unflatten p)) | s <- as | p <- Ps ]
+    /**
+     * TODO: Figure out what this represents for the docs.
+     * [FIPS-202] Section 3.1.
+     */
+    type ell = lg2 w
+    type State = [5][5][w]
 
-pad : {r, m}
-    ( fin r, fin m
-    , r >= 1
-    ) => [m] -> [(m + 2) /^ r][r]
-pad M = split (M # [True] # zero # [True])
+    squeeze : {r} (fin r, r >= 0, b >= r) => State -> [inf]
+    squeeze A = take`{r} (flatten A) # squeeze`{r = r} (Keccak_f A)
 
-Keccak_f : State -> State
-Keccak_f A0 = rounds ! 0
-    where
-        rounds = [A0] # [ Round RC A | RC <- RCs | A <- rounds ]
+    absorb : {r, n} (fin r, fin n, b >= r) => [n][r] -> State
+    absorb Ps = as ! 0
+        where
+            as = [zero] # [ Keccak_f (s ^ (unflatten p)) | s <- as | p <- Ps ]
 
-Round : State -> State -> State
-Round RC A = ι RC (χ (π (ρ (θ A))))
+    pad : {r, m}
+        ( fin r, fin m
+        , r >= 1
+        ) => [m] -> [(m + 2) /^ r][r]
+    pad M = split (M # [True] # zero # [True])
 
-/**
- * One of the step mappings that's part of a round of Keccak-p.
- *
- * [FIPS-202] Section 3.2.1.
- */
-θ : State -> State
-θ A = A' where
-    C = [ xor a | a <- A ]
-    D = [ C @ x ^ (C @ y <<< 1)
-        // In the spec, this is denoted `(x-1) mod 5` for 0 <= x < 5.
-        | (x:[8]) <- [4,0,1,2,3]
-        // In the spec, this is denoted `(x+1) mod 5` for 0 <= x < 5.
-        | (y:[8]) <- [1,2,3,4,0]
-        ]
-    A' = [ [ a ^ (D @ x) | a <- A @ x ] | (x:[8]) <- [0 .. 4] ]
+    Keccak_f : State -> State
+    Keccak_f A0 = rounds ! 0
+        where
+            rounds = [A0] # [ Round RC A | RC <- RCs | A <- rounds ]
 
-/**
- * One of the step mappings that's part of a round of Keccak-p.
- *
- * [FIPS-202] Section 3.2.2.
- */
-ρ : State -> State
-ρ A = groupBy`{5} [ a <<< r | a <- join A | (r:[8]) <- R ]
-    where
-        R = [
-            00, 36, 03, 41, 18,
-            01, 44, 10, 45, 02,
-            62, 06, 43, 15, 61,
-            28, 55, 25, 21, 56,
-            27, 20, 39, 08, 14
-        ]
+    Round : State -> State -> State
+    Round RC A = ι RC (χ (π (ρ (θ A))))
 
-/**
- * One of the step mappings that's part of a round of Keccak-p.
- *
- * [FIPS-202] Section 3.2.3.
- */
-π : State -> State
-π A = groupBy`{5} [ A @ ((x + 3*y) % 5) @ x
-                  | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
-                  ]
+    /**
+     * One of the step mappings that's part of a round of Keccak-p.
+     *
+     * [FIPS-202] Section 3.2.1.
+     */
+    θ : State -> State
+    θ A = A' where
+        C = [ xor a | a <- A ]
+        D = [ C @ x ^ (C @ y <<< 1)
+            // In the spec, this is denoted `(x-1) mod 5` for 0 <= x < 5.
+            | (x:[8]) <- [4,0,1,2,3]
+            // In the spec, this is denoted `(x+1) mod 5` for 0 <= x < 5.
+            | (y:[8]) <- [1,2,3,4,0]
+            ]
+        A' = [ [ a ^ (D @ x) | a <- A @ x ] | (x:[8]) <- [0 .. 4] ]
 
-/**
- * One of the step mappings that's part of a round of Keccak-p.
- *
- * [FIPS-202] Section 3.2.4.
- */
-χ : State -> State
-χ A = groupBy`{5} [ (A @ x @ y) ^ (~ A @ ((x + 1) % 5) @ y
-                                  && A @ ((x + 2) % 5) @ y)
-                  | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
-                  ]
+    /**
+     * One of the step mappings that's part of a round of Keccak-p.
+     *
+     * [FIPS-202] Section 3.2.2.
+     */
+    ρ : State -> State
+    ρ A = groupBy`{5} [ a <<< r | a <- join A | (r:[8]) <- R ]
+        where
+            R = [
+                00, 36, 03, 41, 18,
+                01, 44, 10, 45, 02,
+                62, 06, 43, 15, 61,
+                28, 55, 25, 21, 56,
+                27, 20, 39, 08, 14
+            ]
 
-/**
- * One of the step mappings that's part of a round of Keccak-p.
- *
- * [FIPS-202] Section 3.2.5.
- */
-ι : State -> State -> State
-ι RC A = A ^ RC
+    /**
+     * One of the step mappings that's part of a round of Keccak-p.
+     *
+     * [FIPS-202] Section 3.2.3.
+     */
+    π : State -> State
+    π A = groupBy`{5} [ A @ ((x + 3*y) % 5) @ x
+                    | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
+                    ]
 
-RCs : {n} (fin n, 24 >= n, n == 12 + 2 * ell) => [n]State
-RCs = take`{n} [ [[take`{w} RC] # zero] # zero | RC <- RCs64 ]
+    /**
+     * One of the step mappings that's part of a round of Keccak-p.
+     *
+     * [FIPS-202] Section 3.2.4.
+     */
+    χ : State -> State
+    χ A = groupBy`{5} [ (A @ x @ y) ^ (~ A @ ((x + 1) % 5) @ y
+                                    && A @ ((x + 2) % 5) @ y)
+                    | (x:[8]) <- [0..4], (y:[8]) <- [0..4]
+                    ]
 
-RCs64 : [24][64]
-RCs64 = join (transpose [
-    [0x0000000000000001, 0x000000008000808B],
-    [0x0000000000008082, 0x800000000000008B],
-    [0x800000000000808A, 0x8000000000008089],
-    [0x8000000080008000, 0x8000000000008003],
-    [0x000000000000808B, 0x8000000000008002],
-    [0x0000000080000001, 0x8000000000000080],
-    [0x8000000080008081, 0x000000000000800A],
-    [0x8000000000008009, 0x800000008000000A],
-    [0x000000000000008A, 0x8000000080008081],
-    [0x0000000000000088, 0x8000000000008080],
-    [0x0000000080008009, 0x0000000080000001],
-    [0x000000008000000A, 0x8000000080008008]
-])
+    /**
+     * One of the step mappings that's part of a round of Keccak-p.
+     *
+     * [FIPS-202] Section 3.2.5.
+     */
+    ι : State -> State -> State
+    ι RC A = A ^ RC
 
-unflatten : {r} (b >= r) => [r] -> State
-unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse (p # zero)))))
+    RCs : {n} (fin n, 24 >= n, n == 12 + 2 * ell) => [n]State
+    RCs = take`{n} [ [[take`{w} RC] # zero] # zero | RC <- RCs64 ]
 
-flatten : State -> [5 * 5 * w]
-flatten A = reverse (join (reverse (join (transpose A))))
+    RCs64 : [24][64]
+    RCs64 = join (transpose [
+        [0x0000000000000001, 0x000000008000808B],
+        [0x0000000000008082, 0x800000000000008B],
+        [0x800000000000808A, 0x8000000000008089],
+        [0x8000000080008000, 0x8000000000008003],
+        [0x000000000000808B, 0x8000000000008002],
+        [0x0000000080000001, 0x8000000000000080],
+        [0x8000000080008081, 0x000000000000800A],
+        [0x8000000000008009, 0x800000008000000A],
+        [0x000000000000008A, 0x8000000080008081],
+        [0x0000000000000088, 0x8000000000008080],
+        [0x0000000080008009, 0x0000000080000001],
+        [0x000000008000000A, 0x8000000080008008]
+    ])
 
-xor : {a, c} (fin a) => [a][c] -> [c]
-xor xs = xors ! 0
-    where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
+    unflatten : {r} (b >= r) => [r] -> State
+    unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse (p # zero)))))
+
+    flatten : State -> [5 * 5 * w]
+    flatten A = reverse (join (reverse (join (transpose A))))
+
+    xor : {a, c} (fin a) => [a][c] -> [c]
+    xor xs = xors ! 0
+        where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
+
+    lfsr : [inf]
+    lfsr = [ p!0 | p <- ps ]
+        where
+        /* powers of x modulo m */
+        ps = [0x01] # [ pmod (pmult p 0b10) m | p <- ps ]
+        m = <| x^^8 + x^^6 + x^^5 + x^^4 + 1 |>
 
 property RC_correct i j =
     (i:[8]) < 24 ==> (j:[8]) < 7 ==> RCs64@i!(2^^j - 1) == lfsr@(j + 7*i)
 
-lfsr : [inf]
-lfsr = [ p!0 | p <- ps ]
-    where
-    /* powers of x modulo m */
-    ps = [0x01] # [ pmod (pmult p 0b10) m | p <- ps ]
-    m = <| x^^8 + x^^6 + x^^5 + x^^4 + 1 |>
-
 /**
  * See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2
  * ```repl
- * :prove unflatten_correct`{w=1600}
+ * :prove unflatten_correct`{n=1600}
  * ```
- * TODO: These hardcoded 64s might be wrong.
+ * TODO: These hardcoded 64s are wrong when `n =/= 1600`.
  */
+unflatten_correct : {n} (fin n, b >= n) => [12] -> [12] -> [12] -> [n] -> Bit
 property unflatten_correct x y z p =
     x < 5 ==> y < 5 ==> z < (64:[12]) ==>
     p@((5*y + x)*64 + z) == unflatten p @ x @ y ! z
 
 /**
  * ```repl
- * :prove flatten_correct`{w=1600}
+ * :prove flatten_correct
  * ```
  */
 property flatten_correct s =

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -20,7 +20,7 @@ parameter
     /**
      * Width: the fixed length of the strings that are permuted.
      *
-     * This restricts `b` to the valid permutation widths:
+     * The type constraint restricts `b` to the valid permutation widths:
      * 25, 50, 100, 200, 400, 800, and 1600.
      * In particular, the final constraint enforces that `b / 25` is exactly a
      * power of two, so 0 and any other multiple of 25 are invalid.
@@ -32,8 +32,16 @@ parameter
 
     /**
      * Rounds: the number of iterations of an internal transformation.
-     *
      * [FIPS-202] Section 3 (intro).
+     *
+     * Note: this is currently specialized to a fixed value relative to `b`.
+     * This limitation matches the `Keccak-f` requirement, but is not
+     * necessary for the more generic `Keccak-p`permutation.
+     * For the standardized SHA3 parameter sets, only `Keccak-f` is required.
+     * [FIPS-202] Section 3.4.
+     *
+     * @design we intend to refactor this and the RC functions to allow the
+     * fully generic Keccak-p implementation.
      */
     type nr : #
     type constraint (fin nr, nr > 0, nr == 12 + 2 * (lg2 ( b / 25)))
@@ -49,14 +57,16 @@ parameter
  * Keccak family of sponge functions.
  *
  * At this time, the implementation is not generic with respect to the sponge
- * construction.
+ * construction; this implementation "inlines" the sponge algorithm (Alg 8)
+ * with the specific functions for Keccak (Sec 5.2).
+ * [FIPS-202] Section 4, Algorithm 8; instantiated as in Section 5.2.
  */
 Keccak : {m, d}
     (fin m, fin d) => [m] -> [d]
 Keccak M = take`{d} (extend (Ss ! 0)) where
     // Step 1.
     P = M # pad `{x = r, m = m}
-    // Step 2. We leave the type `n` implicit.
+    // Step 2.
     type n = (m + 2) /^ r
     // Step 3. `c` is a parameter for this module.
     // Step 4. Ps = P_0, ..., P_{n-1}.
@@ -83,7 +93,8 @@ private
     type w = b / 25
 
     /**
-     * TODO: Figure out what this represents for the docs.
+     * The binary logarithm of the lane size; used to determine the size of
+     * the round constant.
      * [FIPS-202] Section 3.1.
      */
     type ell = lg2 w
@@ -95,28 +106,18 @@ private
     type State = [5][5][w]
 
     /**
+     * Convert a string into a state array.
      * [FIPS-202] Section 3.1.2.
      */
     unflatten : [b] -> State
     unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse p))))
 
     /**
+     * Convert a state array into a string.
      * [FIPS-202] Section 3.1.3.
      */
     flatten : State -> [5 * 5 * w]
     flatten A = reverse (join (reverse (join (transpose A))))
-
-    /**
-     * Padding rule `pad10*1`.
-     *
-     * This function produces padding e.g. a string with an appropriate length
-     * to append to another string.
-     * [FIPS-202] Section 5.1.
-     *
-     * TODO: add notes about j equivalence and why the return type here makes sense.
-     */
-    pad : {x, m} (fin x, fin m, x >= 1) => [x * ((m + 2) /^ x) - m]
-    pad = [1] # zero # [1]
 
     /**
      * One of the step mappings that's part of a round of Keccak-p.
@@ -133,6 +134,11 @@ private
             | (y:[8]) <- [1,2,3,4,0]
             ]
         A' = [ [ a ^ (D @ x) | a <- A @ x ] | (x:[8]) <- [0 .. 4] ]
+
+        xor : {a, l} (fin a) => [a][l] -> [l]
+        xor xs = xors ! 0
+            where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
+
 
     /**
      * One of the step mappings that's part of a round of Keccak-p.
@@ -174,16 +180,22 @@ private
     /**
      * One of the step mappings that's part of a round of Keccak-p.
      *
-     * [FIPS-202] Section 3.2.5.
+     * [FIPS-202] Section 3.2.5, Algorithm 6 (kind of).
      */
     ι : State -> State -> State
     ι RC A = A ^ RC
 
+    /**
+     * Format the hard-coded round constant values.
+     *
+     * [FIPS-202] Section 3.2.5.
+     */
     RCs : {n} (fin n, 24 >= n, n == 12 + 2 * ell) => [n]State
     RCs = take`{n} [ [[take`{w} RC] # zero] # zero | RC <- RCs64 ]
 
     /**
-     * Hardcode the ??? values for b = 6400.
+     * Hardcode the round constant values for b = 1600.
+     * [FIPS-202] Section 3.2.5.
      */
     RCs64 : [24][64]
     RCs64 = join (transpose [
@@ -202,6 +214,27 @@ private
     ])
 
     /**
+     * Padding rule `pad10*1`.
+     *
+     * This function produces padding e.g. a string with an appropriate length
+     * to append to another string.
+     * [FIPS-202] Section 5.1.
+     *
+     * Note: The spec says the output length is a positive multiple of `x` and
+     * defines it to be, basically: `(- m - 2) mod x + 2`. We can't encode this
+     * exactly as-is in the type signature because Cryptol doesn't support
+     * negative numbers in types (`-m`). Instead, we do the following:
+     *      (m + 2)           : The minimum length of the original message and
+     *                        : the padding
+     *      (m + 2) /^ x      : The multiplier of `x` that determines the
+     *                        : ultimate length of the message + padding
+     * x * ((m + 2) /^ x)     : The total length of the message + padding
+     * x * ((m + 2) /^ x) - m : The total length of the padding alone
+     */
+    pad : {x, m} (fin x, fin m, x >= 1) => [x * ((m + 2) /^ x) - m]
+    pad = [1] # zero # [1]
+
+    /**
      * Keccak-f family of permutations.
      *
      * [FIPS-202] Section 3.4.
@@ -214,22 +247,36 @@ private
             S' = flatten (rounds ! 0)
 
 
+    /**
+     * The round function for `Keccak-p`. Denoted `Rnd` in the spec.
+     * [FIPS-202] Section 3.3.
+     */
     Round : State -> State -> State
     Round RC A = ι RC (χ (π (ρ (θ A))))
 
-    xor : {a, l} (fin a) => [a][l] -> [l]
-    xor xs = xors ! 0
-        where xors = [zero] # [ x ^ z | x <- xs | z <- xors ]
 
+/**
+ * Equivalence property showing that the hard-coded round constants
+ * match the description in the spec.
+ * [FIPS-202] Section 3.2.5.
+ *
+ * This takes about 6 seconds to prove.
+ * ```repl
+ * :prove RC_correct
+ * ```
+ */
+RC_correct : [8] -> [8] -> Bool
+property RC_correct i j =
+    // See Algorithm 6, Step 3.
+    i < 24 ==> j < `ell ==> RCs64@i!(2^^j - 1) == lfsr@(j + 7*i)
+    where
+    // Algorithm 5.
     lfsr : [inf]
     lfsr = [ p!0 | p <- ps ]
         where
         /* powers of x modulo m */
         ps = [0x01] # [ pmod (pmult p 0b10) m | p <- ps ]
         m = <| x^^8 + x^^6 + x^^5 + x^^4 + 1 |>
-
-property RC_correct i j =
-    (i:[8]) < 24 ==> (j:[8]) < 7 ==> RCs64@i!(2^^j - 1) == lfsr@(j + 7*i)
 
 /**
  * See https://keccak.team/files/Keccak-reference-3.0.pdf, Section 1.2
@@ -243,6 +290,7 @@ property unflatten_correct x y z p =
     p@((5*y + x)*`w + z) == unflatten p @ x @ y ! z
 
 /**
+ * Flatten and unflatten must be each other's inverses.
  * ```repl
  * :prove flatten_correct
  * ```

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -40,8 +40,21 @@ parameter
 
 Keccak : {r, m}
     ( fin r, fin m, b >= r, r >= 1) => [m] -> [inf]
-Keccak M = squeeze `{r = r} (absorb Ps)
-    where Ps = pad `{r = r} M
+Keccak M = extend (Ss ! 0) where
+    // Step 1.
+    P = M # pad `{x = r, m = m}
+    // Step 2. We leave the type `n` implicit.
+    // Step k3.
+    type c = b - r
+    // Step 4. Ps = P_0, ..., P_{n-1}.
+    Ps = split P : [_][r]
+    // Step 5.
+    S = zero : [b]
+    // Step 6. We create a list `Ss` instead of overwriting the variable `S`.
+    Ss = [S] # [Keccak_f (S' ^ (Pi # (zero : [c]))) | Pi <- Ps | S' <- Ss]
+    // Step 7 - 9. This step is sometimes known as "squeeze".
+    extend : [b] -> [inf]
+    extend Z = (take`{r} Z) # extend (Keccak_f Z)
 
 private
     /**
@@ -57,27 +70,17 @@ private
     type ell = lg2 w
     type State = [5][5][w]
 
-    squeeze : {r} (fin r, r >= 0, b >= r) => State -> [inf]
-    squeeze A = take`{r} (flatten A) # squeeze`{r = r} (Keccak_f A)
-
-    absorb : {r, n} (fin r, fin n, b >= r) => [n][r] -> State
-    absorb Ps = as ! 0
-        where
-            as = [zero] # [ Keccak_f (s ^ (unflatten p)) | s <- as | p <- Ps ]
-
-    pad : {r, m}
-        ( fin r, fin m
-        , r >= 1
-        ) => [m] -> [(m + 2) /^ r][r]
-    pad M = split (M # [True] # zero # [True])
-
-    Keccak_f : State -> State
-    Keccak_f A0 = rounds ! 0
-        where
-            rounds = [A0] # [ Round RC A | RC <- RCs | A <- rounds ]
-
-    Round : State -> State -> State
-    Round RC A = ι RC (χ (π (ρ (θ A))))
+    /**
+     * Padding rule `pad10*1`.
+     *
+     * This function produces padding e.g. a string with an appropriate length
+     * to append to another string.
+     * [FIPS-202] Section 5.1.
+     *
+     * TODO: add notes about j equivalence and why the return type here makes sense.
+     */
+    pad : {x, m} (fin x, fin m, x >= 1) => [x * ((m + 2) /^ x) - m]
+    pad = [1] # zero # [1]
 
     /**
      * One of the step mappings that's part of a round of Keccak-p.
@@ -158,6 +161,22 @@ private
         [0x0000000080008009, 0x0000000080000001],
         [0x000000008000000A, 0x8000000080008008]
     ])
+
+    /**
+     * Keccak-f family of permutations.
+     *
+     * [FIPS-202] Section 3.4.
+     */
+    Keccak_f : [b] -> [b]
+    Keccak_f S = S'
+        where
+            A0 = unflatten S
+            rounds = [A0] # [ Round RC A | RC <- RCs | A <- rounds ]
+            S' = flatten (rounds ! 0)
+
+
+    Round : State -> State -> State
+    Round RC A = ι RC (χ (π (ρ (θ A))))
 
     unflatten : {r} (b >= r) => [r] -> State
     unflatten p = transpose (groupBy`{5} (reverse (groupBy`{w} (reverse (p # zero)))))

--- a/Primitive/Keyless/Hash/keccak.cry
+++ b/Primitive/Keyless/Hash/keccak.cry
@@ -61,9 +61,8 @@ parameter
  * with the specific functions for Keccak (Sec 5.2).
  * [FIPS-202] Section 4, Algorithm 8; instantiated as in Section 5.2.
  */
-Keccak : {m, d}
-    (fin m, fin d) => [m] -> [d]
-Keccak M = take`{d} (extend (Ss ! 0)) where
+Keccak : {d, m} (fin m) => [m] -> [d]
+Keccak M = take`{front=d, back=inf} (extend (Ss ! 0)) where
     // Step 1.
     P = M # pad `{x = r, m = m}
     // Step 2.


### PR DESCRIPTION
Addresses part of #132, but doesn't complete it.

This PR updates the high-level structure of SHA-3 to more closely imitate the spec. In particular, it:
- adds parameters to the `keccak` implementation to reduce per-function parameterization
- rearranges code to more closely match the order that things appear in the spec and to make many methods private.
- adds documentation on the high-level functions

~One effect of this is to change the way that the hash and XOF functions are called; a remaining TODO for this PR is to fix all of the downstream failures that result from this API change.~ Addressed this with clarified types instead of changing a dozen downstream files! Yay!

Several things here are being left to future PRs. I'll write up issues for these before this PR is merged.
- many functions don't really look like their spec equivalents. Lower-level modifications of this kind are being saved for a separate PR
- some of the keccak implementation is overly specific to the SHA-3 instantiation parameters, when the spec writes it as more generic. Reducing hard-coded parameters (`nr` specifically) that don't affect the SHA-3 instantiations is being saved for a separate PR.