### PR TITLE
Fix broken README links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ repository are listed below.
 |                            | Primitive                                                                              | Synthesis | Verification |
 |----------------------------|----------------------------------------------------------------------------------------|-----------|--------------|
 | **Block Cipher**           | [AES](Primitive/Symmetric/Cipher/Block/AES)                                            |           |              |
-|                            | [Triple DES](Primitive/Symmetric/Cipher/Block/TripleDES.cry)                           |           |              |
+|                            | [Triple DES](Primitive/Symmetric/Cipher/Block/TripleDES.md)                            |           |              |
 | **Stream Cipher**          | [ChaCha20-Poly1305](Primitive/Symmetric/Cipher/Authenticated/ChaChaPolyCryptolIETF.md) |           |              |
 | **Message Authentication** | [HMAC](Primitive/Symmetric/MAC/HMAC.cry)                                               |           |              |
 | **Digital Signature**      | [ECDSA](Primitive/Asymmetric/Signature/ECDSA)                                          |           |              |
@@ -28,8 +28,9 @@ repository are listed below.
 |                            | [FALCON](Primitive/Asymmetric/Signature/FALCON/1.2/)                                   |           |              |
 |                            | [CRYSTALS Dilithium](Primitive/Asymmetric/Signature/Dilithium/)                        |           |              |
 | **Hash**                   | [SHA1](Primitive/Keyless/Hash/SHA1.cry)                                                |           |              |
-|                            | [SHA256](Primitive/Keyless/Hash/SHA256.cry)                                            |           |              |
-|                            | [SHA2, SHA3](Primitive/Keyless/Hash/SHA.cry)                                           |           |              |
+|                            | [SHA256](Primitive/Keyless/Hash/SHA2/Instantiations/SHA256.cry)                        |           |              |
+|                            | [SHA2](Primitive/Keyless/Hash/SHA2/)                                                   |           |              |
+|                            | [SHA3](Primitive/Keyless/Hash/SHA3/)                                                   |           |              | 
 | **Asymmetric Encryption**  | [CRYSTALS Kyber](Primitive/Asymmetric/Cipher/Kyber/3.01/)                              |           |              |
 |                            | [RSA](Primitive/Asymmetric/Cipher/RSA.cry)                                             |           |              |
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ repository are listed below.
 | **Hash**                   | [SHA1](Primitive/Keyless/Hash/SHA1.cry)                                                |           |              |
 |                            | [SHA256](Primitive/Keyless/Hash/SHA2/Instantiations/SHA256.cry)                        |           |              |
 |                            | [SHA2](Primitive/Keyless/Hash/SHA2/)                                                   |           |              |
-|                            | [SHA3](Primitive/Keyless/Hash/SHA3/)                                                   |           |              | 
+|                            | [SHA3](Primitive/Keyless/Hash/SHA3/)                                                   |           |              |
 | **Asymmetric Encryption**  | [CRYSTALS Kyber](Primitive/Asymmetric/Cipher/Kyber/3.01/)                              |           |              |
 |                            | [RSA](Primitive/Asymmetric/Cipher/RSA.cry)                                             |           |              |
 
@@ -44,7 +44,7 @@ The repository contains Cryptol implementations of the selected cryptographic sc
 | Type          | PKE/KEM                                                   | Signature                                                       |
 |---------------|-----------------------------------------------------------|-----------------------------------------------------------------|
 | Lattice-based | [CRYSTALS Kyber](Primitive/Asymmetric/Cipher/Kyber/3.01/) | [CRYSTALS Dilithium](Primitive/Asymmetric/Signature/Dilithium/) |
-|               | [ML-KEM](Primitive/Asymmetric/Cipher/ML-KEM/)             |                                                                 |
+|               | [ML-KEM](Primitive/Asymmetric/Cipher/ML_KEM/)             |                                                                 |
 |               |                                                           | [FALCON](Primitive/Asymmetric/Signature/FALCON/1.2/)            |
 | Hash-based    |                                                           | [SPHINCS+](Primitive/Asymmetric/Signature/SphincsPlus/)         |
 


### PR DESCRIPTION
Links to Cryptol implementations of TripleDES, SHA256, SHA2, SHA3 are fixed.

This _probably_ closes issue #120.