### PR TITLE
Add one-time signature scheme from XMSS

### DIFF
--- a/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTSP_SHA2_256.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTSP_SHA2_256.cry
@@ -20,7 +20,7 @@
  * @copyright Galois, Inc.
  * @author Marcella Hastings <marcella@galois.com>
  */
-module Primitive::Asymmetric::Signature::XMSS::Instantiations::WOTS_256 =
+module Primitive::Asymmetric::Signature::XMSS::Instantiations::WOTSP_SHA2_256 =
     Primitive::Asymmetric::Signature::XMSS::Wots where
         import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256
 

--- a/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTS_256.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTS_256.cry
@@ -1,3 +1,25 @@
+/**
+ * An instantiation of the WOTS+ one-time signature scheme.
+ *
+ * These parameters and naming are drawn from [SP-800-208], Section 5 (Table 9
+ * and Section 5.1). The same parameters are also defined in [RFC-8391]
+ * Section 5.1 (SHA2 with `n = 32`).
+ *
+ * References:
+ * [SP-800-208]: David A. Cooper, Daniel C. Apon, Quynh H. Dang, Michael S.
+ *     Davidson, Morris J. Dworkin, and Carl A. Miller. Recommendation for
+ *     Stateful Hash-Based Signature Schemes. (National Institute of Standards
+ *     and Technology, Gaithersburg, MD), NIST Special Publication (SP) NIST
+ *     SP 800-208. October 2020.
+ *     @see https://doi.org/10.6028/NIST.SP.800-208
+ * [RFC-8391]: Andreas Huelsing, Denis Butin, Stefan-Lukas Gazdag, Joost
+ *     Rijneveld, and Aziz Mohaisen. XMSS: eXtended Merkle Signature Scheme.
+ *     Internet Requests for Comments (RFC) 8391. May 2018.
+ *     @see https://datatracker.ietf.org/doc/rfc8391
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
+ */
 module Primitive::Asymmetric::Signature::XMSS::Instantiations::WOTS_256 =
     Primitive::Asymmetric::Signature::XMSS::Wots where
         import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256

--- a/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTS_256.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Instantiations/WOTS_256.cry
@@ -1,0 +1,11 @@
+module Primitive::Asymmetric::Signature::XMSS::Instantiations::WOTS_256 =
+    Primitive::Asymmetric::Signature::XMSS::Wots where
+        import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256
+
+        type n = 32
+        type w = 16
+
+        F KEY M = split (SHA256::hash (join ((zero : [32][8]) # KEY # M)))
+        PRF KEY M = split (SHA256::hash (join ((zero : [31][8]) # [(3 : [8])] # KEY # M)))
+
+

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -46,6 +46,26 @@ parameter
     PRF : [n][8] -> [32][8] -> [n][8]
 
     /**
+     * A length value (fixed with respect to `n` and `w`).
+     * [RFC-8391] Section 3.1.1.
+     */
+    type len_1 = (8 * n) /^ (lg2 w)
+
+    /**
+     * A length value (fixed with respect to `n` and `w`).
+     * [RFC-8391] Section 3.1.1.
+     */
+
+    type len_2 = lg2 (len_1 * (w - 1)) / lg2 w + 1
+
+    /**
+     * The number of `n`-byte string elements in a WOTS+ private key, public key,
+     * and signature.
+     * [RFC-8391] Section 3.1.1.
+     */
+    type len = len_1 + len_2
+
+    /**
      * The `len` parameter fits in 32 bits.
      *
      * This implicit fact about our inputs is hard for Cryptol to infer, so we
@@ -59,8 +79,7 @@ parameter
      * This can also be observed from the computed `len` values from the valid
      * parameter sets in Section 5.2.
      */
-    type constraint (32 >= width ((8 * n) /^ (lg2 w)
-        + lg2 (((8 * n) /^ (lg2 w)) * (w - 1)) / lg2 w + 1))
+    type constraint (32 >= width len)
 
 /**
  * A byte is a sequence of 8 bits using big-endian representation.
@@ -74,22 +93,6 @@ type Byte = [8]
  */
 type Word = [32]
 
-/**
- * A length value.
- * [RFC-8391] Section 3.1.1.
- */
-type len_1 = (8 * n) /^ (lg2 w)
-/**
- * A length value.
- * [RFC-8391] Section 3.1.1.
- */
-type len_2 = lg2 (len_1 * (w - 1)) / lg2 w + 1
-/**
- * The number of `n`-byte string elements in a WOTS+ private key, public key,
- * and signature.
- * [RFC-8391] Section 3.1.1.
- */
-type len = len_1 + len_2
 
 /**
  * Address scheme for randomizing hash function calls in the OTS scheme.
@@ -191,8 +194,6 @@ private
         BM = PRF SEED ADRS'''
 
         tmp' = F KEY (tmp ^ BM)
-
-private
 
     /**
      * Convert a byte string into a set of base-`w` numbers.

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -7,9 +7,15 @@
  * Warning: If a private key is used to sign two different messages, the scheme
  * becomes insecure! Cryptol cannot protect against this failure mode!
  *
+ * Instantiation warnings
+ * - The WOTS+ signature scheme includes a checksum. Per [RFC-8391], the
+ *   checksum can fit in 32 bits _when instantiated with an approved parameter
+ *   set_. This must not be instantiated with any parameter set for which the
+ *   checksum does not fit in 32 bits. [RFC-8391] Section 3.1.5.
+ *
  * References:
  * [RFC-8391]: Andreas Huelsing, Denis Butin, Stefan-Lukas Gazdag, Joost
- *     Rijneveld, and Aziz Mohaisen. XMSS: eXtended Merkle Signatuer Scheme.
+ *     Rijneveld, and Aziz Mohaisen. XMSS: eXtended Merkle Signature Scheme.
  *     Internet Requests for Comments (RFC) 8391. May 2018.
  *     @see https://datatracker.ietf.org/doc/rfc8391
  */
@@ -88,11 +94,18 @@ parameter
 type Byte = [8]
 
 /**
+ * Convert a non-negative integer to a binary representation in big-endian
+ * byte order.
+ * [RFC-8391] Section 2.4.
+ */
+toByte : {y, m} (fin y, y * 8 >= m) => [m] -> [y]Byte
+toByte x = split (zext x)
+
+/**
  * A word is a 32-bit sequence used to define hash addresses.
  * [RFC-8391] Section 2.5.
  */
 type Word = [32]
-
 
 /**
  * Address scheme for randomizing hash function calls in the OTS scheme.
@@ -274,3 +287,47 @@ private
         test4 = base_w`{4} [0x12, 0x34] == [1, 2, 3, 4]
         test3 = base_w`{3} [0x12, 0x34] == [1, 2, 3]
         test2 = base_w`{2} [0x12, 0x34] == [1, 2]
+
+
+/**
+ * A WOTS+ signature.
+ * [RFC-8391] Section 3.1.5.
+ */
+type Signature = [len][n]Byte
+
+/**
+ * Generate a signature from a private key and a message.
+ * [RFC-8391] Section 3.1.5, Algorithm 5.
+ *
+ * The checksum in the signature algorithm must fit in 32 bits; we enforce this
+ * using a constraint in the type signature; it will always be true for the
+ * approved parameter sets.
+ */
+WOTS_sign : {len_2_bytes} (
+    // The checksum must fit in 32 bits.
+    width (len_1 * (w - 1) * 2^^8) <= 32,
+
+    // The checksum is padded to this length...
+    len_2_bytes == (len_2 * lg2 w) /^ 8,
+    // ...so this length must be at least 32 bits / 4 bytes.
+    // This will always be true for the approved parameter sets, but Cryptol
+    // can't infer it in general.
+    4 <= len_2_bytes
+) => [n]Byte -> PrivateKey -> OTSHashAddress -> [n]Byte -> Signature
+WOTS_sign M sk ADRS SEED = sig where
+    // Convert message to base `w`.
+    msg = base_w`{len_1} M
+
+    // Compute checksum.
+    csum = sum [ `w - 1 - msg_i | msg_i <- msg ]
+
+    // Convert `csum` to base `w`.
+    csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
+    // `len_2_bytes` is defined in the type signature.
+    msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
+    sig = [sig_i where
+            ADRS_i = setChainAddress ADRS i
+            sig_i = chain sk_i 0 msg_i SEED ADRS_i
+        | i <- [0..len-1]
+        | sk_i <- sk
+        | msg_i <- msg' ]

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -331,3 +331,33 @@ WOTS_sign M sk ADRS SEED = sig where
         | i <- [0..len-1]
         | sk_i <- sk
         | msg_i <- msg' ]
+
+/**
+ * Compute a WOTS+ public key from a message and its signature.
+ * [RFC-8391] Section 3.1.6, Algorithm 6.
+ *
+ * The result of this function must be compared to the given public key. If
+ * the values are not equal, the signature MUST be rejected. This algorithm
+ * does not actually reject any signatures!!
+ */
+WOTS_pkFromSig : {len_2_bytes} (
+    len_2_bytes == (len_2 * lg2 w) /^ 8,
+    4 <= len_2_bytes
+) => [n]Byte -> Signature -> OTSHashAddress -> [n]Byte -> PublicKey
+WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
+    // Convert message to base `w`.
+    msg = base_w`{len_1} M
+
+    // Compute checksum.
+    csum = sum [ `w - 1 - msg_i | msg_i <- msg ]
+
+    // Convert csum to base `w`.
+    csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
+    // `len_2_bytes` is defined in the type signature.
+    msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
+    tmp_pk = [tmp_pk_i where
+            ADRS_i = setChainAddress ADRS i
+            tmp_pk_i = chain sig_i msg_i (`w - 1 - msg_i) SEED ADRS_i
+        | i <- [0..len-1]
+        | sig_i <- sig
+        | msg_i <- msg' ]

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -143,7 +143,6 @@ genPK sk ADRS SEED = pk where
         | i <- [0..len-1]
         | ski <- sk]
 
-
 private
     /**
      * Set the chain address word (in the 6th position) in an `OTSHashAddress`.
@@ -173,6 +172,7 @@ private
 
     /**
      * Chaining function that iterates `F` on the input `X`, `s` times.
+     * [RFC-8391] Section 3.1.2, Algorithm 2.
      */
     chain : [n]Byte -> Word -> Word -> [n]Byte -> OTSHashAddress -> [n]Byte
     chain X i s SEED ADRS = return where
@@ -191,3 +191,85 @@ private
         BM = PRF SEED ADRS'''
 
         tmp' = F KEY (tmp ^ BM)
+
+private
+
+    /**
+     * Convert a byte string into a set of base-`w` numbers.
+     *
+     * This uses the manual bit-shifting algorithm described in the spec. The
+     * spec is not very particular about bit widths of the helper variables or
+     * the output; we made the following choices:
+     * - `total`: holds each byte of the input, so `[8]`
+     * - `in`: holds the index showing where we are in the input. We use an
+     *   `Integer`, although this could also be `[width len_X]`.
+     * - `bits`: holds the number of bits processed in the current byte. This is
+     *   never larger than 8, but due to the way we've defined the type
+     *   constraint on `w`, it's easier to leave some extra space, so `[8]`.
+     * - `basew`: The output of this function is eventually used as a parameter
+     *   to `chain`, so we pad each base-`w` number to be a `Word` (`[32]`).
+     *
+     * [RFC-8391] Section 2.6, Algorithm 1.
+     */
+    base_w : {out_len, len_X} (
+            fin len_X,
+            out_len <= 8 * len_X / lg2 w)
+        => [len_X]Byte -> [out_len]Word
+    base_w X = basew where
+        // Steps 8 - 13. Define how the helper variables (`total`, `in`, `bits`)
+        // are updated in each round.
+        update_helpers : ([8], Integer, [8]) -> ([8], Integer, [8])
+        update_helpers (total, in, bits) =
+            if bits == 0 then (
+                X@in,
+                in + 1,
+                8 - lg2 `w )
+            else (total, in, bits - lg2 `w)
+
+        // Step 7. Define the number of iterations we need.
+        type consumed = out_len
+
+        // Step 14. Compute the set of base-`w` numbers. `zext` converts an
+        // 8-bit value to a `Word`.
+        basew = take`{consumed} [ zext ((total >> bits) && (`w - 1))
+            // Steps 1-5. Initialize helper variables (and update them for each
+            // round). The first element is dropped because the first variable
+            // update happens before computing any output values.
+            | (total, in, bits) <- drop`{1} (iterate update_helpers (0, 0, 0))]
+
+    /**
+     * As a point of interest, we also implement the `base_w` function using
+     * built-in Cryptol functions, just regrouping the bits into the desired
+     * arrangement.
+     */
+    base_w_cryptol : {out_len, len_X} (
+        fin len_X,
+        out_len <= 8 * len_X / lg2 w)
+        => [len_X]Byte -> [out_len]Word
+    base_w_cryptol X = map zext (groupBy`{lg2 w} (take (join X)))
+
+    /**
+     * Proof that the "Cryptollish" version matches the spec.
+     * Parameter sets are chosen based on the instantiations that appear in
+     * the spec (Algorithms 5 and 6).
+     * ```repl
+     * :prove base_wsMatch`{len_1, n * 8}
+     * type len_2_bytes = len_2 * lg2 w /^ 8
+     * :prove base_wsMatch`{len_2, len_2_bytes}
+     * ```
+     */
+    base_wsMatch : {O, L} (fin L, O <= 8 * L / lg2 w) => [L]Byte -> Bit
+    property base_wsMatch X = base_w`{O, L} X == base_w_cryptol X
+
+    /**
+     * The spec provides several examples when `w = 16`.
+     * [RFC-8391] Section 2.6.
+     * ```repl
+     * :prove base_wExamplesWork`{}
+     * ```
+     */
+    base_wExamplesWork : (w == 16) => Bit
+    property base_wExamplesWork = test4 && test3 && test2 where
+        test4 = base_w`{4} [0x12, 0x34] == [1, 2, 3, 4]
+        test3 = base_w`{3} [0x12, 0x34] == [1, 2, 3]
+        test2 = base_w`{2} [0x12, 0x34] == [1, 2]

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -18,6 +18,9 @@
  *     Rijneveld, and Aziz Mohaisen. XMSS: eXtended Merkle Signature Scheme.
  *     Internet Requests for Comments (RFC) 8391. May 2018.
  *     @see https://datatracker.ietf.org/doc/rfc8391
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
  */
 module Primitive::Asymmetric::Signature::XMSS::Wots where
 

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -54,8 +54,12 @@ parameter
     /**
      * A length value (fixed with respect to `n` and `w`).
      * [RFC-8391] Section 3.1.1.
+     *
+     * The type constraint is drawn from Algorithm 5, where a computed
+     * checksum of length `len_1 * (w - 1) * 2^8` must fit in 32 bits.
      */
     type len_1 = (8 * n) /^ (lg2 w)
+    type constraint (width (len_1 * (w - 1) * 2^^8) <= 32)
 
     /**
      * A length value (fixed with respect to `n` and `w`).
@@ -63,6 +67,13 @@ parameter
      */
 
     type len_2 = lg2 (len_1 * (w - 1)) / lg2 w + 1
+
+    /**
+     * This type is used in Algorithms 5 and 6; it's the padded length of a
+     * checksum. The checksum has an upper bound of 32 bits, so the padding
+     * must be at least 32 bits.
+     */
+    type len_2_bytes = (len_2 * lg2 w) /^ 8
 
     /**
      * The number of `n`-byte string elements in a WOTS+ private key, public key,
@@ -98,8 +109,10 @@ type Byte = [8]
  * byte order.
  * [RFC-8391] Section 2.4.
  */
-toByte : {y, m} (fin y, y * 8 >= m) => [m] -> [y]Byte
-toByte x = split (zext x)
+toByte : {y, m} (fin y, y > 0) => [m] -> [y]Byte
+toByte x
+    | m <= 8 * y => split (zext x)
+    | m > 8 * y => split (take x)
 
 /**
  * A word is a 32-bit sequence used to define hash addresses.
@@ -303,17 +316,7 @@ type Signature = [len][n]Byte
  * using a constraint in the type signature; it will always be true for the
  * approved parameter sets.
  */
-WOTS_sign : {len_2_bytes} (
-    // The checksum must fit in 32 bits.
-    width (len_1 * (w - 1) * 2^^8) <= 32,
-
-    // The checksum is padded to this length...
-    len_2_bytes == (len_2 * lg2 w) /^ 8,
-    // ...so this length must be at least 32 bits / 4 bytes.
-    // This will always be true for the approved parameter sets, but Cryptol
-    // can't infer it in general.
-    4 <= len_2_bytes
-) => [n]Byte -> PrivateKey -> OTSHashAddress -> [n]Byte -> Signature
+WOTS_sign : [n]Byte -> PrivateKey -> OTSHashAddress -> [n]Byte -> Signature
 WOTS_sign M sk ADRS SEED = sig where
     // Convert message to base `w`.
     msg = base_w`{len_1} M
@@ -323,7 +326,7 @@ WOTS_sign M sk ADRS SEED = sig where
 
     // Convert `csum` to base `w`.
     csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
-    // `len_2_bytes` is defined in the type signature.
+    // `len_2_bytes` is defined at the top level in the `parameter` block.
     msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
     sig = [sig_i where
             ADRS_i = setChainAddress ADRS i
@@ -340,10 +343,7 @@ WOTS_sign M sk ADRS SEED = sig where
  * the values are not equal, the signature MUST be rejected. This algorithm
  * does not actually reject any signatures!!
  */
-WOTS_pkFromSig : {len_2_bytes} (
-    len_2_bytes == (len_2 * lg2 w) /^ 8,
-    4 <= len_2_bytes
-) => [n]Byte -> Signature -> OTSHashAddress -> [n]Byte -> PublicKey
+WOTS_pkFromSig : [n]Byte -> Signature -> OTSHashAddress -> [n]Byte -> PublicKey
 WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
     // Convert message to base `w`.
     msg = base_w`{len_1} M
@@ -353,7 +353,7 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
 
     // Convert csum to base `w`.
     csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
-    // `len_2_bytes` is defined in the type signature.
+    // `len_2_bytes` is defined at the top level in the `parameter` block.
     msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
     tmp_pk = [tmp_pk_i where
             ADRS_i = setChainAddress ADRS i
@@ -361,3 +361,16 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
         | i <- [0..len-1]
         | sig_i <- sig
         | msg_i <- msg' ]
+
+/**
+ * Each function takes about 50 seconds to run, so a single execution of this
+ * property takes ~3 minutes.
+ * ```repl
+ * :set tests = 1
+ * :check WOTSisCorrect
+ * ```
+ */
+property WOTSisCorrect M sk ADRS SEED = tmp_pk == pk where
+    pk = genPK sk ADRS SEED
+    sig = WOTS_sign M sk ADRS SEED
+    tmp_pk = WOTS_pkFromSig M sig ADRS SEED

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -268,9 +268,16 @@ private
             | (total, in, bits) <- drop`{1} (iterate update_helpers (0, 0, 0))]
 
     /**
-     * As a point of interest, we also implement the `base_w` function using
-     * built-in Cryptol functions, just regrouping the bits into the desired
-     * arrangement.
+     * Convert a byte string into a set of base-`w` numbers.
+     *
+     * This uses standard built-in Cryptol functions to achieve the same
+     * functionality as the spec version; rather than manually bit shifting, it
+     * regroups the bits into the desired arrangement. This is about 5x faster
+     * than the spec version.
+     *
+     * Note that this depends on the top-level type constraint restricting `w`
+     * to either 4 or 16. I am not sure the grouping would work as well if we
+     * were working in a base that was not a power of 2.
      */
     base_w : {out_len, len_X} (
         fin len_X,
@@ -279,9 +286,10 @@ private
     base_w X = map zext (groupBy`{lg2 w} (take (join X)))
 
     /**
-     * Proof that the "Cryptollish" version matches the spec.
-     * Parameter sets are chosen based on the instantiations that appear in
-     * the spec (Algorithms 5 and 6).
+     * Proof that the Cryptol-ish version of `base_w` matches the spec version.
+     *
+     * Parameter for the following tests are chosen based on the instantiations
+     * that appear in the spec (Algorithms 5 and 6).
      * ```repl
      * :prove base_wsMatch`{len_1, n * 8}
      * type len_2_bytes = len_2 * lg2 w /^ 8
@@ -354,7 +362,7 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
     // Compute checksum.
     csum = sum [ `w - 1 - msg_i | msg_i <- msg ]
 
-    // Convert csum to base `w`.
+    // Convert `csum` to base `w`.
     csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
     // `len_2_bytes` is defined at the top level in the `parameter` block.
     msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
@@ -366,8 +374,7 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
         | msg_i <- msg' ]
 
 /**
- * Each function takes about 50 seconds to run, so a single execution of this
- * property takes ~3 minutes.
+ * A single execution of this property takes ~2 minutes.
  * ```repl
  * :set tests = 1
  * :check WOTSisCorrect

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -38,9 +38,13 @@ parameter
     /**
      * The Winternitz parameter. This must be either 4 or 16.
      * [RFC-8391] Section 3.1.1.
+     *
+     * The type constraint is a bit contrived, but it requires that
+     * `w` is in the range `[0, 16]`, is divisible by 4 (`{0, 4, 8, 12, 16}`),
+     * and is congruent to 1 mod 3 (`{4, 16}`).
      */
     type w : #
-    type constraint (fin w, w % 4 == 0, w % 12 == 4, w <= 16)
+    type constraint (fin w, w % 4 == 0, w % 3 == 1, w <= 16)
 
     /**
      * A keyed cryptographic hash function that takes a key and a message.
@@ -58,8 +62,8 @@ parameter
      * A length value (fixed with respect to `n` and `w`).
      * [RFC-8391] Section 3.1.1.
      *
-     * The type constraint is drawn from Algorithm 5, where a computed
-     * checksum of length `len_1 * (w - 1) * 2^8` must fit in 32 bits.
+     * The type constraint is drawn from Algorithm 5, where a computed checksum
+     * of length `len_1 * (w - 1) * 2^8` must fit in 32 bits for correctness.
      */
     type len_1 = (8 * n) /^ (lg2 w)
     type constraint (width (len_1 * (w - 1) * 2^^8) <= 32)
@@ -84,7 +88,7 @@ parameter
      * This implicit fact about our inputs is hard for Cryptol to infer, so we
      * state it explicitly.
      *
-     * It is implied by the `WOTS_genPK` function, which sets the chain address
+     * It is implied by the `genPK` function, which sets the chain address
      * of an OTS hash address to an iterator that varies from 0 to `len-1`.
      * The chain address is restricted to one 32-bit word. See [RFC-8391]
      * Algorithm 4.
@@ -155,6 +159,10 @@ type OTSHashAddress = [8 * 4]Byte
  * Implementors must independently audit private key generation!
  *
  * [RFC-8391] Section 3.1.3.
+ *
+ * An implementation may also use a cryptographically secure pseudorandom
+ * method to generate the private key from a single `n`-byte value. See
+ * [RFC-8391] Section 3.1.7 for a sample method.
  */
 type PrivateKey = [len][n]Byte
 
@@ -168,6 +176,7 @@ type PublicKey = [len][n]Byte
 
 /**
  * Generate a WOTS+ public key from a private key.
+ * [RFC-8391] Section 3.1.4, Algorithm 4 (called `WOTS_genPK` in the spec).
  */
 genPK : PrivateKey -> OTSHashAddress -> [n]Byte -> PublicKey
 genPK sk ADRS SEED = pk where
@@ -323,14 +332,14 @@ type Signature = [len][n]Byte
 
 /**
  * Generate a signature from a private key and a message.
- * [RFC-8391] Section 3.1.5, Algorithm 5.
+ * [RFC-8391] Section 3.1.5, Algorithm 5 (called `WOTS_sign` in the spec).
  *
  * The checksum in the signature algorithm must fit in 32 bits; we enforce this
  * using a constraint in the type signature; it will always be true for the
  * approved parameter sets.
  */
-WOTS_sign : [n]Byte -> PrivateKey -> OTSHashAddress -> [n]Byte -> Signature
-WOTS_sign M sk ADRS SEED = sig where
+sign : [n]Byte -> PrivateKey -> OTSHashAddress -> [n]Byte -> Signature
+sign M sk ADRS SEED = sig where
     // Convert message to base `w`.
     msg = base_w`{len_1} M
 
@@ -350,14 +359,14 @@ WOTS_sign M sk ADRS SEED = sig where
 
 /**
  * Compute a WOTS+ public key from a message and its signature.
- * [RFC-8391] Section 3.1.6, Algorithm 6.
+ * [RFC-8391] Section 3.1.6, Algorithm 6 (called `WOTS_pkFromSig` in the spec).
  *
  * The result of this function must be compared to the given public key. If
  * the values are not equal, the signature MUST be rejected. This algorithm
  * does not actually reject any signatures!!
  */
-WOTS_pkFromSig : [n]Byte -> Signature -> OTSHashAddress -> [n]Byte -> PublicKey
-WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
+pkFromSig : [n]Byte -> Signature -> OTSHashAddress -> [n]Byte -> PublicKey
+pkFromSig M sig ADRS SEED = tmp_pk where
     // Convert message to base `w`.
     msg = base_w`{len_1} M
 
@@ -384,5 +393,5 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
  */
 property WOTSisCorrect M sk ADRS SEED = tmp_pk == pk where
     pk = genPK sk ADRS SEED
-    sig = WOTS_sign M sk ADRS SEED
-    tmp_pk = WOTS_pkFromSig M sig ADRS SEED
+    sig = sign M sk ADRS SEED
+    tmp_pk = pkFromSig M sig ADRS SEED

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -72,13 +72,6 @@ parameter
     type len_2 = lg2 (len_1 * (w - 1)) / lg2 w + 1
 
     /**
-     * This type is used in Algorithms 5 and 6; it's the padded length of a
-     * checksum. The checksum has an upper bound of 32 bits, so the padding
-     * must be at least 32 bits.
-     */
-    type len_2_bytes = (len_2 * lg2 w) /^ 8
-
-    /**
      * The number of `n`-byte string elements in a WOTS+ private key, public key,
      * and signature.
      * [RFC-8391] Section 3.1.1.
@@ -111,11 +104,20 @@ type Byte = [8]
  * Convert a non-negative integer to a binary representation in big-endian
  * byte order.
  * [RFC-8391] Section 2.4.
+ *
+ * Note: the spec is not explicit about what to do when `m < 8y` -- e.g. when
+ * converting to `y` bytes means truncating the integer representation,
+ * rather than padding it with 0s. We chose this behavior based on the
+ * reference implementation that accompanies the spec.
+ * @see https://github.com/XMSS/xmss-reference/blob/master/utils.c#L6
+ * [RFC-8391] Section 7.
+ *
+ * Essentially, we pad with zeros if needed (using `zext`), then `drop` any
+ * unnecessary padding (and potentially also drop some bits of the original
+ * integer).
  */
-toByte : {y, m} (fin y, y > 0) => [m] -> [y]Byte
-toByte x
-    | m <= 8 * y => split (zext x)
-    | m > 8 * y => split (take x)
+toByte : {y, m} (fin y, fin m) => [m] -> [y]Byte
+toByte x = split (drop (zext`{max m (y * 8)} x))
 
 /**
  * A word is a 32-bit sequence used to define hash addresses.
@@ -337,7 +339,7 @@ WOTS_sign M sk ADRS SEED = sig where
 
     // Convert `csum` to base `w`.
     csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
-    // `len_2_bytes` is defined at the top level in the `parameter` block.
+    type len_2_bytes = (len_2 * lg2 w) /^ 8
     msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
     sig = [sig_i where
             ADRS_i = setChainAddress ADRS i
@@ -364,7 +366,7 @@ WOTS_pkFromSig M sig ADRS SEED = tmp_pk where
 
     // Convert `csum` to base `w`.
     csum' = csum << (8 - (`(len_2 * lg2 w) % 8))
-    // `len_2_bytes` is defined at the top level in the `parameter` block.
+    type len_2_bytes = (len_2 * lg2 w) /^ 8
     msg' = msg # base_w`{len_2} (toByte`{len_2_bytes} csum')
     tmp_pk = [tmp_pk_i where
             ADRS_i = setChainAddress ADRS i

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -45,6 +45,23 @@ parameter
      */
     PRF : [n][8] -> [32][8] -> [n][8]
 
+    /**
+     * The `len` parameter fits in 32 bits.
+     *
+     * This implicit fact about our inputs is hard for Cryptol to infer, so we
+     * state it explicitly.
+     *
+     * It is implied by the `WOTS_genPK` function, which sets the chain address
+     * of an OTS hash address to an iterator that varies from 0 to `len-1`.
+     * The chain address is restricted to one 32-bit word. See [RFC-8391]
+     * Algorithm 4.
+     *
+     * This can also be observed from the computed `len` values from the valid
+     * parameter sets in Section 5.2.
+     */
+    type constraint (32 >= width ((8 * n) /^ (lg2 w)
+        + lg2 (((8 * n) /^ (lg2 w)) * (w - 1)) / lg2 w + 1))
+
 /**
  * A byte is a sequence of 8 bits using big-endian representation.
  * [RFC-8391] Section 2.1.
@@ -66,7 +83,7 @@ type len_1 = (8 * n) /^ (lg2 w)
  * A length value.
  * [RFC-8391] Section 3.1.1.
  */
-type len_2 = (lg2 (len_1 * (w - 1)) / (lg2 w)) + 1
+type len_2 = lg2 (len_1 * (w - 1)) / lg2 w + 1
 /**
  * The number of `n`-byte string elements in a WOTS+ private key, public key,
  * and signature.
@@ -92,10 +109,53 @@ type len = len_1 + len_2
  */
 type OTSHashAddress = [8 * 4]Byte
 
+/**
+ * A private, or secret, key in WOTS+ is a length `len` array of `n`-byte
+ * strings.
+ *
+ * It represents the start nodes in a set of hash chains.
+ *
+ * ⚠️ Warning ⚠️: A private key MUST be selected randomly from the uniform
+ * distribution or selected using a cryptographically secure pseudorandom
+ * process! Cryptol cannot verify that a `PrivateKey` was chosen suitably!
+ * Implementors must independently audit private key generation!
+ *
+ * [RFC-8391] Section 3.1.3.
+ */
+type PrivateKey = [len][n]Byte
+
+/**
+ * A WOTS+ public key is a length `len` array of `n`-byte strings.
+ *
+ * It represents the end nodes i a set of length-`w` hash chains, where the
+ * start nodes are defined in the corresponding `PrivateKey`.
+ */
+type PublicKey = [len][n]Byte
+
+/**
+ * Generate a WOTS+ public key from a private key.
+ */
+genPK : PrivateKey -> OTSHashAddress -> [n]Byte -> PublicKey
+genPK sk ADRS SEED = pk where
+    pk = [ pki where
+            ADRSi = setChainAddress ADRS i
+            pki = chain ski 0 (`w - 1) SEED ADRSi
+        | i <- [0..len-1]
+        | ski <- sk]
+
+
 private
+    /**
+     * Set the chain address word (in the 6th position) in an `OTSHashAddress`.
+     * This setter is defined implicitly in the spec.
+     * [RFC-8391] Section 2.7.
+     */
+    setChainAddress : OTSHashAddress -> Word -> OTSHashAddress
+    setChainAddress address value =
+        take`{5 * 4} address # (split value) # drop`{6 * 4} address
 
     /**
-     * Set the hash address word (in the 5th position) in an `OTSHashAddress`.
+     * Set the hash address word (in the 7th position) in an `OTSHashAddress`.
      * This setter is defined implicitly in the spec.
      * [RFC-8391] Section 2.7.
      */

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -238,11 +238,11 @@ private
      *
      * [RFC-8391] Section 2.6, Algorithm 1.
      */
-    base_w : {out_len, len_X} (
+    base_w_spec : {out_len, len_X} (
             fin len_X,
             out_len <= 8 * len_X / lg2 w)
         => [len_X]Byte -> [out_len]Word
-    base_w X = basew where
+    base_w_spec X = basew where
         // Steps 8 - 13. Define how the helper variables (`total`, `in`, `bits`)
         // are updated in each round.
         update_helpers : ([8], Integer, [8]) -> ([8], Integer, [8])
@@ -269,11 +269,11 @@ private
      * built-in Cryptol functions, just regrouping the bits into the desired
      * arrangement.
      */
-    base_w_cryptol : {out_len, len_X} (
+    base_w : {out_len, len_X} (
         fin len_X,
         out_len <= 8 * len_X / lg2 w)
         => [len_X]Byte -> [out_len]Word
-    base_w_cryptol X = map zext (groupBy`{lg2 w} (take (join X)))
+    base_w X = map zext (groupBy`{lg2 w} (take (join X)))
 
     /**
      * Proof that the "Cryptollish" version matches the spec.
@@ -286,7 +286,7 @@ private
      * ```
      */
     base_wsMatch : {O, L} (fin L, O <= 8 * L / lg2 w) => [L]Byte -> Bit
-    property base_wsMatch X = base_w`{O, L} X == base_w_cryptol X
+    property base_wsMatch X = base_w_spec`{O, L} X == base_w X
 
     /**
      * The spec provides several examples when `w = 16`.

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -1,0 +1,69 @@
+/**
+ * WOTS+: One-Time Signatures.
+ *
+ * This signature primitive is used in the XMSS signature scheme. In WOTS+,
+ * a private key can be used to sign any message, but each private key can
+ * be used only once.
+ * Warning: If a private key is used to sign two different messages, the scheme
+ * becomes insecure! Cryptol cannot protect against this failure mode!
+ *
+ * References:
+ * [RFC-8391]: Andreas Huelsing, Denis Butin, Stefan-Lukas Gazdag, Joost
+ *     Rijneveld, and Aziz Mohaisen. XMSS: eXtended Merkle Signatuer Scheme.
+ *     Internet Requests for Comments (RFC) 8391. May 2018.
+ *     @see https://datatracker.ietf.org/doc/rfc8391
+ */
+module Primitive::Asymmetric::Signature::XMSS::Wots where
+
+
+parameter
+    /**
+     * Security parameter.
+     * This defines the message length, the length of a private key, the length
+     * of a public key, and a signature element (in bytes).
+     * [RFC-8391] Section 3.1.1.
+     */
+    type n : #
+    type constraint (fin n)
+
+    /**
+     * The Winternitz parameter. This must be either 4 or 16.
+     * [RFC-8391] Section 3.1.1.
+     */
+    type w : #
+    type constraint (fin w, w % 4 == 0, w % 12 == 4, w <= 16)
+
+    /**
+     * A keyed cryptographic hash function that takes a key and a message.
+     * [RFC-8391] Section 3.1.1.1.
+     */
+    F : [n][8] -> [n][8] -> [n][8]
+
+    /**
+     * A pseudorandom function that takes a key and an index.
+     * [RFC-8391] Section 3.1.1.1.
+     */
+    PRF : [n][8] -> [32][8] -> [n][8]
+
+/**
+ * A byte is a sequence of 8 bits using big-endian representation.
+ * [RFC-8391] Section 2.1.
+ */
+type Byte = [8]
+
+/**
+ * A length value.
+ * [RFC-8391] Section 3.1.1.
+ */
+type len_1 = (8 * n) /^ (lg2 w)
+/**
+ * A length value.
+ * [RFC-8391] Section 3.1.1.
+ */
+type len_2 = (lg2 (len_1 * (w - 1)) / (lg2 w)) + 1
+/**
+ * The number of `n`-byte string elements in a WOTS+ private key, public key,
+ * and signature.
+ * [RFC-8391] Section 3.1.1.
+ */
+type len = len_1 + len_2

--- a/Primitive/Asymmetric/Signature/XMSS/Wots.cry
+++ b/Primitive/Asymmetric/Signature/XMSS/Wots.cry
@@ -52,6 +52,12 @@ parameter
 type Byte = [8]
 
 /**
+ * A word is a 32-bit sequence used to define hash addresses.
+ * [RFC-8391] Section 2.5.
+ */
+type Word = [32]
+
+/**
  * A length value.
  * [RFC-8391] Section 3.1.1.
  */
@@ -67,3 +73,61 @@ type len_2 = (lg2 (len_1 * (w - 1)) / (lg2 w)) + 1
  * [RFC-8391] Section 3.1.1.
  */
 type len = len_1 + len_2
+
+/**
+ * Address scheme for randomizing hash function calls in the OTS scheme.
+ * [RFC-8391] Section 2.5.
+ *
+ * The address breaks down 7 components, each 1 word long unless specified.
+ * 1. Layer address
+ * 2-3. Tree address (2 Words)
+ * 4. Type (fixed at 0)
+ * 5. OTS address
+ * 6. Chain address
+ * 7. Hash address
+ * 8. keyAndMask
+ *
+ * Note that this isn't defined in terms of the `Word` type because it's
+ * operated on by things that require arrays of bytes.
+ */
+type OTSHashAddress = [8 * 4]Byte
+
+private
+
+    /**
+     * Set the hash address word (in the 5th position) in an `OTSHashAddress`.
+     * This setter is defined implicitly in the spec.
+     * [RFC-8391] Section 2.7.
+     */
+    setHashAddress : OTSHashAddress -> Word -> OTSHashAddress
+    setHashAddress address value =
+        take`{6 * 4} address # (split value) # drop`{7 * 4} address
+
+    /**
+     * Set the `keyAndMask` word (the last position) in an `OTSHashAddress`.
+     * This setter is defined implicitly in the spec.
+     * [RFC-8391] Section 2.7.
+     */
+    setKeyAndMask : OTSHashAddress -> Word -> OTSHashAddress
+    setKeyAndMask address value = take`{7 * 4} address # split value
+
+    /**
+     * Chaining function that iterates `F` on the input `X`, `s` times.
+     */
+    chain : [n]Byte -> Word -> Word -> [n]Byte -> OTSHashAddress -> [n]Byte
+    chain X i s SEED ADRS = return where
+        return = if s == 0 then
+                X
+            else if i + s > `w - 1 then
+                error "Invalid `s` and `i` parameters passed to `chain`"
+            else
+                tmp'
+        tmp = chain X i (s - 1) SEED ADRS
+
+        ADRS' = setHashAddress ADRS (i + s - 1)
+        ADRS'' = setKeyAndMask ADRS' 0
+        KEY = PRF SEED ADRS''
+        ADRS''' = setKeyAndMask ADRS'' 1
+        BM = PRF SEED ADRS'''
+
+        tmp' = F KEY (tmp ^ BM)


### PR DESCRIPTION
Closes #162.

This adds [the WOTS+ signature scheme](https://datatracker.ietf.org/doc/html/rfc8391#section-3.1) that's used in XMSS. It's very slow! About 50s for each public function (keygen, sign, verify). 

This will be unusably slow in the context of XMSS -- e.g. XMSS key generation calls WOTS+ key generation `2^h` times, where $h \in [10, 16, 20]$ -- for the largest parameter, this would take 1048576 minutes, or roughly 728 days, without accounting for the additional hashing that happens in XMSS.

Anyway I optimized `base_w` a bit but I think the main cost is coming from the recursive hashing; if we want this to be faster we will probably need to go look at SHA2 (the required parameter sets) and SHA3 (the optional parameter sets). In general, the goal of these specs is not to be performant -- it's just to look exactly like the written NIST specs -- but this appears to be getting so slow that we won't even be able to check basic properties of XMSS.

Another point of interest: this takes longer than usual to load (~10 - 30s), I suspect because the type constraints have a lot of computation in them.

Aside from performance, I think this is fairly straightforwardly representative of the spec. I'll add some inline questions and notes.