### PR TITLE
Add hint pack functions

### DIFF
--- a/Common/OptionUtils.cry
+++ b/Common/OptionUtils.cry
@@ -1,0 +1,36 @@
+/**
+ * Convenience functions for working with `Option`s.
+ */
+module Common::OptionUtils where
+
+isSome : {a} Option a -> Bit
+isSome opt = case opt of
+    Some _ -> True
+    None -> False
+
+isNone : {a} Option a -> Bit
+isNone opt = ~ isSome opt
+
+/**
+ * Map an `Option a` to an `Option b` by applying a function to a contained
+ * value (if `Some`) or returns `None` (if `None`).
+ */
+mapOption : {a, b} (a -> b) -> Option a -> Option b
+mapOption f opt = case opt of
+    Some x -> Some (f x)
+    None -> None
+
+/**
+ * Flatten a nested option into a single option.
+ */
+flatten : {a} Option (Option a) -> Option a
+flatten opt = case opt of
+    Some opt' -> opt'
+    None -> None
+
+/**
+ * Map an `Option a` to an `Option b` by calling `mapOption` on a function that
+ * produces an `Option b`, then flattening the result.
+ */
+flatMap : {a, b} (a -> Option b) -> Option a -> Option b
+flatMap f opt = flatten (mapOption f opt)

--- a/Common/OptionUtils.cry
+++ b/Common/OptionUtils.cry
@@ -1,5 +1,8 @@
 /**
  * Convenience functions for working with `Option`s.
+ *
+ * @copyright Galois, Inc.
+ * @author Marcella Hastings <marcella@galois.com>
  */
 module Common::OptionUtils where
 
@@ -15,22 +18,23 @@ isNone opt = ~ isSome opt
  * Map an `Option a` to an `Option b` by applying a function to a contained
  * value (if `Some`) or returns `None` (if `None`).
  */
-mapOption : {a, b} (a -> b) -> Option a -> Option b
-mapOption f opt = case opt of
+optApply : {a, b} (a -> b) -> Option a -> Option b
+optApply f opt = case opt of
     Some x -> Some (f x)
     None -> None
 
 /**
- * Flatten a nested option into a single option.
+ * Flatten a nested `Option` into a single `Option` that is `Some` only if
+ * both original `Option`s are `Some`.
  */
-flatten : {a} Option (Option a) -> Option a
-flatten opt = case opt of
+optFlatten : {a} Option (Option a) -> Option a
+optFlatten opt = case opt of
     Some opt' -> opt'
     None -> None
 
 /**
- * Map an `Option a` to an `Option b` by calling `mapOption` on a function that
- * produces an `Option b`, then flattening the result.
+ * Map an `Option a` to an `Option b` by calling `optApply` on a function that
+ * produces an `Option b`, then `optFlatten`ing the result.
  */
-flatMap : {a, b} (a -> Option b) -> Option a -> Option b
-flatMap f opt = flatten (mapOption f opt)
+optFlatApply: {a, b} (a -> Option b) -> Option a -> Option b
+optFlatApply f opt = optFlatten (optApply f opt)

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -126,7 +126,7 @@ parameter
      */
     type k : #
     type ell : #
-    type constraint (fin k, fin ell, k > 0, width k <= 8)
+    type constraint (fin k, fin ell, k > 0)
 
     /**
      * Private key range; the private key is a polynomial whose coefficients
@@ -142,9 +142,18 @@ parameter
     /**
      * Maximum Hamming weight for the hint component of a signature.
      * [FIPS-204] Section 4, Table 1.
+     *
+     * The constraints are drawn from [FIPS-204] Algorithm 21:
+     * - `ω > 0`: in Step 16, we have to be able to compute `ω - 1`.
+     * - `width ω <= 8`: This is an implementation artifact from Step 4. We
+     *   compare `ω` to an element in `y`, which is a byte. Cryptol will
+     *   default to fitting `ω` into in a byte. This is always true with the
+     *   allowable parameter sets. If a new parameter set is released with a
+     *   much larger `ω`, we can modify the implementation to remove this
+     *   constraint without affecting functionality.
      */
     type ω : #
-    type constraint (fin ω, width ω <= 8)
+    type constraint (fin ω, ω > 0, width ω <= 8)
 
 /**
  * A 512th root of unity in `Z_q`.
@@ -297,16 +306,16 @@ HintBitUnpack y = h20 where
     // Get the values of `h` and `Index` after the loop in Steps 3 - 15.
     maybe_hAndIndex' = hAndIndexes ! 0
 
-    // This helper function uses recursion to read any leftover bytes in the
-    // first `ω` bytes of `y`; it returns an error if any of them are non-zero.
-    checkZero i =
-        if i > (`ω - 1) then True
-        else if (y@i != zero) then False
-        else checkZero (i + 1)
+    // This helper function reads any "leftover" bytes (e.g. beyond `Index`) in
+    // the first `ω` bytes of `y`; it returns `True` if all of them are zero.
+    checkLeftoverBytes Index = and [i >= Index ==> y@i == 0 | i <- [0..ω - 1]]
 
     // Step 16 - 20.
     h20 = case maybe_hAndIndex' of
-        Some hAndIndex -> if (checkZero Index) then Some (split`{k} h)
+        Some hAndIndex -> if (checkLeftoverBytes Index) then
+                // This `split` converts back to the spec-adherent
+                // representation of `h`.
+                Some (split`{k} h)
             else None
             where (h, Index) = hAndIndex
         None -> None

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -275,7 +275,9 @@ HintBitUnpack y = h___ where
     Step7_14 : Pair -> Byte -> Byte -> Option Pair
     Step7_14 (h, Index) i First =
         if Index < (y@(`ω + i)) then
-            if (Index > First) ==> ((y@(Index - 1)) >= (y@Index)) then None
+            // The `/\` is a short-cutting `and`, equivalent to the nested `if`
+            // statements in the spec.
+            if ((Index > First) /\ (y@(Index - 1) >= y@Index)) then None
             // Recursive call is equivalent to continuing the loop.
             // The constants `i` and `First` do not change between iterations.
             else Step7_14

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -306,18 +306,21 @@ HintBitUnpack y = h20 where
     // Get the values of `h` and `Index` after the loop in Steps 3 - 15.
     maybe_hAndIndex' = hAndIndexes ! 0
 
-    // This helper function reads any "leftover" bytes (e.g. beyond `Index`) in
-    // the first `ω` bytes of `y`; it returns `True` if all of them are zero.
-    checkLeftoverBytes Index = and [i >= Index ==> y@i == 0 | i <- [0..ω - 1]]
-
     // Step 16 - 20.
     h20 = case maybe_hAndIndex' of
-        Some hAndIndex -> if (checkLeftoverBytes Index) then
+        Some hAndIndex -> if checkLeftoverBytes then
                 // This `split` converts back to the spec-adherent
                 // representation of `h`.
                 Some (split`{k} h)
             else None
-            where (h, Index) = hAndIndex
+            where
+                (h, Index) = hAndIndex
+                // This helper reads any "leftover" bytes (e.g. beyond `Index`)
+                // in the first `ω` bytes of `y`; it returns `True` if all of
+                // them are zero.
+                checkLeftoverBytes = and [i >= Index ==> y@i == 0
+                    | i <- [0..ω - 1]]
+
         None -> None
 
 /**

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -40,6 +40,16 @@ type Tq = [256](Z q)
 type R = [256]Integer
 
 /**
+ * The ring of single-variable polynomials over the integers mod 2, modulo
+ * `X^256 + 1`.
+ * [FIPS-204] Section 2.3 and Section 2.4.1.
+ *
+ * We represent individual elements in `ℤ_2` as bits, so this is just a bit
+ * array.
+ */
+type R2 = [256]
+
+/**
  * Wrapper function around SHAKE256, specifying the length `l` in bytes.
  * [FIPS-204] Section 3.7.
  *
@@ -116,6 +126,7 @@ parameter
      */
     type k : #
     type ell : #
+    type constraint (fin k, fin ell, k > 0)
 
     /**
      * Private key range; the private key is a polynomial whose coefficients
@@ -133,6 +144,7 @@ parameter
      * [FIPS-204] Section 4, Table 1.
      */
     type ω : #
+    type constraint (fin ω)
 
 /**
  * A 512th root of unity in `Z_q`.
@@ -188,6 +200,35 @@ CoeffFromHalfByte b =
     else
         if (`η == 4) && (b < 9) then Some (4 - toInteger b)
         else None
+
+/**
+ * Encode a polynomial vector `h` with binary coefficients into a byte string.
+ * [FIPS-204] Section 7.1, Algorithm 20.
+ */
+HintBitPack : [k]R2 -> [ω + k]Byte
+HintBitPack h = yFinal where
+    // Step 1.
+    y0 = zero : [ω + k]Byte
+    // Step 2.
+    Index0 = 0
+    // Steps 3 - 11. This builds a list with all the intermediate values of
+    // `y` and `Index`...
+    yAndIndex = [(y0, Index0)] # [ (y'', Index') where
+            // Steps 5 - 8.
+            (y', Index') = if (h @i @j) != 0 then
+                    (update y Index j, Index + 1)
+                else (y, Index)
+
+            // Step 10.
+            y'' = if j == 255 then
+                    update y' (`ω + i) Index'
+                else y'
+        | (y, Index) <- yAndIndex
+        // Step 3 - 4.
+        | i <- [0..k-1], j <- [0..255]
+    ]
+    // Step 12. ...we return the last `y`.
+    (yFinal, _) = yAndIndex ! 0
 
 /**
  * Sample a polynomial in the ring `Tq`.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -291,12 +291,22 @@ HintBitUnpack y = h20 where
 
 /**
  * Verify that `HintBitUnpack` is the reverse of `HintBitPack`.
+ *
+ * This takes a list of indexes indicating the non-zero elements and constructs
+ * a valid, sparse `h` -- rejection sampling was not a valid option because
+ * sparse-enough `h`s were too rare.
  * ```repl
  * :check HintPackingInverts
  * ```
  */
-property HintPackingInverts h = sum (map toInteger (join (map groupBy`{1} h))) < `ω ==>
-   HintBitUnpack (HintBitPack h) == h
+HintPackingInverts : {w} (w <= ω) => [w][lg2 (256 * k)] -> Bit
+property HintPackingInverts h_Indexes =
+    case HintBitUnpack (HintBitPack h) of
+        Some h' -> h == h'
+        None -> False
+    where
+        // build h out of h_indexes:
+        h = split`{k} [if elem idx h_Indexes then 1 else 0 | idx <- [0..(256 * k) - 1]]
 
 /**
  * Sample a polynomial in the ring `Tq`.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -256,7 +256,7 @@ HintBitPack h = yFinal where
  *   executed with recursion.
  */
 HintBitUnpack : [ω + k]Byte -> Option ([k]R2)
-HintBitUnpack y = h20 where
+HintBitUnpack y = hFinal where
     // Step 1.
     h0 = zero : [k * 256]
     // Step 2.
@@ -279,35 +279,33 @@ HintBitUnpack y = h20 where
         else Step6_15 (h, Index) i
 
     // Steps 6 - 15.
-    Step6_15 (h, Index) i = Step7_14 (h, Index) i First where
+    Step6_15 (h, Index) i = Step7_14 (h, Index) where
         // Step 6.
         First = Index
 
-    // Steps 7 - 14.
-    Step7_14 (h, Index) i First =
-        // Step 7 (condition).
-        if Index < (y@(`ω + i)) then
-            // Step 8 - 11.
-            // The `/\` is a short-cutting `and`, equivalent to the nested `if`
-            // statements in the spec.
-            if ((Index > First) /\ (y@(Index - 1) >= y@Index)) then None
-            // Step 7 (recursive call -- equivalent to continuing the loop).
-            else Step7_14
-                // Step 12.
-                (update h (i*256 + (toInteger (y@Index))) 1,
-                // Step 13.
-                Index + 1)
-                // These variables do not change between iterations.
-                i First
-        // If the loop condition is no longer true, return the current values
-        // of `h` and `Index`.
-        else Some (h, Index)
+        // Steps 7 - 14.
+        Step7_14 (h', Index') =
+            // Step 7 (condition).
+            if Index' < (y@(`ω + i)) then
+                // Step 8 - 11.
+                // The `/\` is a short-cutting `and`, equivalent to the nested
+                // `if` statements in the spec.
+                if ((Index' > First) /\ (y@(Index' - 1) >= y@Index')) then None
+                // Step 7 (recursive call -- equivalent to continuing the loop).
+                else Step7_14
+                    // Step 12.
+                    (update h' (i*256 + (toInteger (y@Index'))) 1,
+                    // Step 13.
+                    Index' + 1)
+            // If the loop condition is no longer true, return the current
+            // values of `h` and `Index`.
+            else Some (h', Index')
 
     // Get the values of `h` and `Index` after the loop in Steps 3 - 15.
     maybe_hAndIndex' = hAndIndexes ! 0
 
     // Step 16 - 20.
-    h20 = case maybe_hAndIndex' of
+    hFinal = case maybe_hAndIndex' of
         Some hAndIndex -> if checkLeftoverBytes then
                 // This `split` converts back to the spec-adherent
                 // representation of `h`.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -237,7 +237,7 @@ HintBitPack h = yFinal where
  * - To simplify updating `h`, we treat it as a single array of size `256k`.
  *   We separate it into the correct `[k]R2` representation in the final step.
  *   We access the array in "the natural way" -- that is, in Step 12, the
- *   element `h[i]_y[Index]` is at index `i * k + y[Index]` in our array.
+ *   element `h[i]_y[Index]` is at index `i * 256 + y[Index]` in our array.
  */
 HintBitUnpack : [ω + k]Byte -> Option ([k]R2)
 HintBitUnpack y = h___ where
@@ -259,20 +259,20 @@ HintBitUnpack y = h___ where
     ]
 
     // Steps 4 - 5.
-    Step4_5 : Byte -> Pair -> Option Pair
+    Step4_5 : Integer -> Pair -> Option Pair
     Step4_5 i (h, Index) = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
             None
         else Step6_15 (h, Index) i
 
     // Steps 6 -15
-    Step6_15 : Pair -> Byte -> Option Pair
+    Step6_15 : Pair -> Integer -> Option Pair
     Step6_15 (h, Index) i = result15 where
         // Step 6.
         First = Index
         result15 = Step7_14 (h, Index) i First
 
     // Steps 7 - 14.
-    Step7_14 : Pair -> Byte -> Byte -> Option Pair
+    Step7_14 : Pair -> Integer -> Byte -> Option Pair
     Step7_14 (h, Index) i First =
         if Index < (y@(`ω + i)) then
             // The `/\` is a short-cutting `and`, equivalent to the nested `if`
@@ -281,7 +281,7 @@ HintBitUnpack y = h___ where
             // Recursive call is equivalent to continuing the loop.
             // The constants `i` and `First` do not change between iterations.
             else Step7_14
-                (update h (i*`k + y@Index) 1,
+                (update h (i*256 + (toInteger (y@Index))) 1,
                 Index + 1)
                 i First
         // If the loop condition is no longer true, return the current values

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -19,8 +19,6 @@
  */
 module Primitive::Asymmetric::Signature::ML_DSA::Specification where
 
-import Common::OptionUtils(flatMap)
-import Common::utils(while)
 import Primitive::Keyless::Hash::SHAKE::SHAKE128 as SHAKE128
 import Primitive::Keyless::Hash::SHAKE::SHAKE256 as SHAKE256
 
@@ -233,18 +231,23 @@ HintBitPack h = yFinal where
     (yFinal, _) = yAndIndex ! 0
 
 /**
+ * Reverses the procedure `HintBitPack`.
+ * [FIPS-204] Section 7.1, Algorithm 21.
+ *
  * This diverges slightly from the spec:
  * - To simplify updating `h`, we treat it as a single array of size `256k`.
  *   We separate it into the correct `[k]R2` representation in the final step.
  *   We access the array in "the natural way" -- that is, in Step 12, the
  *   element `h[i]_y[Index]` is at index `i * 256 + y[Index]` in our array.
+ * - We cannot "return early" when we encounter an error case. Instead, we use
+ *   options to indicate whether a failure has occurred and skip further
+ *   computation when the option is `None`.
+ * - The for loop in Step 3 is executed with a list comprehension. The while
+ *   loop in Step 7 is executed with recursion. The for loop in Step 16 is
+ *   executed with recursion.
  */
 HintBitUnpack : [ω + k]Byte -> Option ([k]R2)
-HintBitUnpack y = h___ where
-    // Useful rename for annotation functions that operate over the stateful
-    // pair of `h` and `Index` used across this function.
-    type Pair = ([k * 256], Byte)
-
+HintBitUnpack y = h20 where
     // Step 1.
     h0 = zero : [k * 256]
     // Step 2.
@@ -252,68 +255,79 @@ HintBitUnpack y = h___ where
 
     // Step 3. Construct a list comprising the values of `h` and `Index`
     // at the end of each iteration of the loop in Steps 3 - 15.
-    hAndIndex = [Some (h0, Index0)] # [
-            flatMap (Step4_5 i) maybe_hAndIndex
-        | maybe_hAndIndex <- hAndIndex
+    hAndIndexes = [Some (h0, Index0)] # [
+            // Call Steps 4-5 if we haven't encountered an error yet.
+            case maybe_hAndIndex of
+                Some hAndIndex -> Step4_5 hAndIndex i
+                None -> None
+        | maybe_hAndIndex <- hAndIndexes
         | i <- [0..k-1]
     ]
 
     // Steps 4 - 5.
-    Step4_5 : Integer -> Pair -> Option Pair
-    Step4_5 i (h, Index) = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
+    Step4_5 (h, Index) i = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
             None
         else Step6_15 (h, Index) i
 
-    // Steps 6 -15
-    Step6_15 : Pair -> Integer -> Option Pair
-    Step6_15 (h, Index) i = result15 where
+    // Steps 6 - 15.
+    Step6_15 (h, Index) i = Step7_14 (h, Index) i First where
         // Step 6.
         First = Index
-        result15 = Step7_14 (h, Index) i First
 
     // Steps 7 - 14.
-    Step7_14 : Pair -> Integer -> Byte -> Option Pair
     Step7_14 (h, Index) i First =
+        // Step 7 (condition).
         if Index < (y@(`ω + i)) then
+            // Step 8 - 11.
             // The `/\` is a short-cutting `and`, equivalent to the nested `if`
             // statements in the spec.
             if ((Index > First) /\ (y@(Index - 1) >= y@Index)) then None
-            // Recursive call is equivalent to continuing the loop.
-            // The constants `i` and `First` do not change between iterations.
+            // Step 7 (recursive call -- equivalent to continuing the loop).
             else Step7_14
+                // Step 12.
                 (update h (i*256 + (toInteger (y@Index))) 1,
+                // Step 13.
                 Index + 1)
+                // These variables do not change between iterations.
                 i First
         // If the loop condition is no longer true, return the current values
         // of `h` and `Index`.
         else Some (h, Index)
 
     // Get the values of `h` and `Index` after the loop in Steps 3 - 15.
-    maybe_hAndIndex = hAndIndex ! 0
+    maybe_hAndIndex' = hAndIndexes ! 0
 
     // This helper function uses recursion to read any leftover bytes in the
     // first `ω` bytes of `y`; it returns an error if any of them are non-zero.
-    checkZero idx =
-        if idx > (`ω - 1) then True
-        else if (y@idx != zero) then False
-        else checkZero (idx + 1)
+    checkZero i =
+        if i > (`ω - 1) then True
+        else if (y@i != zero) then False
+        else checkZero (i + 1)
 
     // Step 16 - 20.
-    h___ = flatMap
-        (\(h, Index) -> if (checkZero Index) then Some (split`{k} h)
+    h20 = case maybe_hAndIndex' of
+        Some hAndIndex -> if (checkZero Index) then Some (split`{k} h)
             else None
-        )
-        maybe_hAndIndex
+            where (h, Index) = hAndIndex
+        None -> None
 
 /**
  * Verify that `HintBitUnpack` is the reverse of `HintBitPack`.
  *
  * This takes a list of indexes indicating the non-zero elements and constructs
- * a valid, sparse `h` -- rejection sampling was not a valid option because
+ * a valid, sparse `h` -- rejection sampling is not a valid option because
  * sparse-enough `h`s were too rare.
+ *
+ * We test the case where we have the maximum number of 1s, a medium number, and
+ * a case where at least one vector should have no non-zero terms at all.
+ * In practice, the hint may fall anywhere in this range.
  * ```repl
- * :check HintPackingInverts
+ * :check HintPackingInverts`{ω}
+ * :check HintPackingInverts`{ω / 2}
+ * :check HintPackingInverts`{3}
  * ```
+ *
+ * Note that this does not test the error cases for `HintBitUnpack`.
  */
 HintPackingInverts : {w} (w <= ω) => [w][lg2 (256 * k)] -> Bit
 property HintPackingInverts h_Indexes =
@@ -321,7 +335,7 @@ property HintPackingInverts h_Indexes =
         Some h' -> h == h'
         None -> False
     where
-        // build h out of h_indexes:
+        // Build `h` out of `h_indexes`:
         h = split`{k} [if elem idx h_Indexes then 1 else 0 | idx <- [0..(256 * k) - 1]]
 
 /**

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -19,6 +19,7 @@
  */
 module Primitive::Asymmetric::Signature::ML_DSA::Specification where
 
+import Common::OptionUtils(flatMap)
 import Common::utils(while)
 import Primitive::Keyless::Hash::SHAKE::SHAKE128 as SHAKE128
 import Primitive::Keyless::Hash::SHAKE::SHAKE256 as SHAKE256
@@ -238,56 +239,69 @@ HintBitPack h = yFinal where
  *   We access the array in "the natural way" -- that is, in Step 12, the
  *   element `h[i]_y[Index]` is at index `i * k + y[Index]` in our array.
  */
-HintBitUnpack : [ω + k]Byte -> [k]R2
-HintBitUnpack y = h20 where
-   // Step 1.
-   h0 = zero : [k * 256]
-   // Step 2.
-   Index0 = 0
-   // Step 3. Construct a list comprising the values of `h` and `Index`
-   // at the end of each iteration of the loop in Steps 3 - 15.
-   hAndIndex = [(h0, Index0)] # [(h', Index') where
-           // Steps 4 - 5.
-           _ = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
-                   error "invalid count"
-               else 0
+HintBitUnpack : [ω + k]Byte -> Option ([k]R2)
+HintBitUnpack y = h___ where
+    // Useful rename for annotation functions that operate over the stateful
+    // pair of `h` and `Index` used across this function.
+    type Pair = ([k * 256], Byte)
 
-           // Step 6.
-           First = Index
+    // Step 1.
+    h0 = zero : [k * 256]
+    // Step 2.
+    Index0 = 0
 
-           // Steps 7 - 14. This loop is uses recursion under the hood and
-           // operates over a state of `(h : [k * 256], Index : Integer)`
-           (h', Index') = while
-               // Step 7 (condition).
-               (\(_, Idx) -> Idx < y@(`ω + i))
-               // Steps 8 - 13 (function body).
-               (\(h_, Idx) ->
-                   if (Idx > First) && (y@(Idx - 1) >= y@Idx) then
-                       error "Invalid y[Index]"
-                   else (
-                       update h_ (i*`k + y@Idx) 1,
-                       Idx + 1)
-               )
-               // Initial value of `h` and `Index` at the beginning of the
-               // loop.
-               (h, Index)
-       | (h, Index) <- hAndIndex
-       | i <- [0..k-1]
-   ]
-   // No direct correlation in the spec; this gets the values of `h` and
-   // `Index` at the end of the `for` loop (e.g. at Step 15).
-   (h15, Index15) = hAndIndex ! 0
+    // Step 3. Construct a list comprising the values of `h` and `Index`
+    // at the end of each iteration of the loop in Steps 3 - 15.
+    hAndIndex = [Some (h0, Index0)] # [
+            flatMap (Step4_5 i) maybe_hAndIndex
+        | maybe_hAndIndex <- hAndIndex
+        | i <- [0..k-1]
+    ]
 
-   // This helper function uses recursion to read any leftover bytes in the
-   // first `ω` bytes of `y`; it returns an error if any of them are non-zero.
-   checkZero idx =
-       if idx > (`ω - 1) then True
-       else if (y@idx != zero) then False
-       else checkZero (idx + 1)
+    // Steps 4 - 5.
+    Step4_5 : Byte -> Pair -> Option Pair
+    Step4_5 i (h, Index) = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
+            None
+        else Step6_15 (h, Index) i
 
-   // Step 16 - 19. Recall that `Index15` is the value of `Index` at Step 15.
-   h20 = if (checkZero Index15) then split h15
-       else error "non-zero entries padding indexes"
+    // Steps 6 -15
+    Step6_15 : Pair -> Byte -> Option Pair
+    Step6_15 (h, Index) i = result15 where
+        // Step 6.
+        First = Index
+        result15 = Step7_14 (h, Index) i First
+
+    // Steps 7 - 14.
+    Step7_14 : Pair -> Byte -> Byte -> Option Pair
+    Step7_14 (h, Index) i First =
+        if Index < (y@(`ω + i)) then
+            if (Index > First) ==> ((y@(Index - 1)) >= (y@Index)) then None
+            // Recursive call is equivalent to continuing the loop.
+            // The constants `i` and `First` do not change between iterations.
+            else Step7_14
+                (update h (i*`k + y@Index) 1,
+                Index + 1)
+                i First
+        // If the loop condition is no longer true, return the current values
+        // of `h` and `Index`.
+        else Some (h, Index)
+
+    // Get the values of `h` and `Index` after the loop in Steps 3 - 15.
+    maybe_hAndIndex = hAndIndex ! 0
+
+    // This helper function uses recursion to read any leftover bytes in the
+    // first `ω` bytes of `y`; it returns an error if any of them are non-zero.
+    checkZero idx =
+        if idx > (`ω - 1) then True
+        else if (y@idx != zero) then False
+        else checkZero (idx + 1)
+
+    // Step 16 - 20.
+    h___ = flatMap
+        (\(h, Index) -> if (checkZero Index) then Some (split`{k} h)
+            else None
+        )
+        maybe_hAndIndex
 
 /**
  * Verify that `HintBitUnpack` is the reverse of `HintBitPack`.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -19,6 +19,7 @@
  */
 module Primitive::Asymmetric::Signature::ML_DSA::Specification where
 
+import Common::utils(while)
 import Primitive::Keyless::Hash::SHAKE::SHAKE128 as SHAKE128
 import Primitive::Keyless::Hash::SHAKE::SHAKE256 as SHAKE256
 
@@ -126,7 +127,7 @@ parameter
      */
     type k : #
     type ell : #
-    type constraint (fin k, fin ell, k > 0)
+    type constraint (fin k, fin ell, k > 0, width k <= 8)
 
     /**
      * Private key range; the private key is a polynomial whose coefficients
@@ -144,7 +145,7 @@ parameter
      * [FIPS-204] Section 4, Table 1.
      */
     type ω : #
-    type constraint (fin ω)
+    type constraint (fin ω, width ω <= 8)
 
 /**
  * A 512th root of unity in `Z_q`.
@@ -229,6 +230,73 @@ HintBitPack h = yFinal where
     ]
     // Step 12. ...we return the last `y`.
     (yFinal, _) = yAndIndex ! 0
+
+/**
+ * This diverges slightly from the spec:
+ * - To simplify updating `h`, we treat it as a single array of size `256k`.
+ *   We separate it into the correct `[k]R2` representation in the final step.
+ *   We access the array in "the natural way" -- that is, in Step 12, the
+ *   element `h[i]_y[Index]` is at index `i * k + y[Index]` in our array.
+ */
+HintBitUnpack : [ω + k]Byte -> [k]R2
+HintBitUnpack y = h20 where
+   // Step 1.
+   h0 = zero : [k * 256]
+   // Step 2.
+   Index0 = 0
+   // Step 3. Construct a list comprising the values of `h` and `Index`
+   // at the end of each iteration of the loop in Steps 3 - 15.
+   hAndIndex = [(h0, Index0)] # [(h', Index') where
+           // Steps 4 - 5.
+           _ = if (y@(`ω + i) < Index) || (y@(`ω + i) > `ω) then
+                   error "invalid count"
+               else 0
+
+           // Step 6.
+           First = Index
+
+           // Steps 7 - 14. This loop is uses recursion under the hood and
+           // operates over a state of `(h : [k * 256], Index : Integer)`
+           (h', Index') = while
+               // Step 7 (condition).
+               (\(_, Idx) -> Idx < y@(`ω + i))
+               // Steps 8 - 13 (function body).
+               (\(h_, Idx) ->
+                   if (Idx > First) && (y@(Idx - 1) >= y@Idx) then
+                       error "Invalid y[Index]"
+                   else (
+                       update h_ (i*`k + y@Idx) 1,
+                       Idx + 1)
+               )
+               // Initial value of `h` and `Index` at the beginning of the
+               // loop.
+               (h, Index)
+       | (h, Index) <- hAndIndex
+       | i <- [0..k-1]
+   ]
+   // No direct correlation in the spec; this gets the values of `h` and
+   // `Index` at the end of the `for` loop (e.g. at Step 15).
+   (h15, Index15) = hAndIndex ! 0
+
+   // This helper function uses recursion to read any leftover bytes in the
+   // first `ω` bytes of `y`; it returns an error if any of them are non-zero.
+   checkZero idx =
+       if idx > (`ω - 1) then True
+       else if (y@idx != zero) then False
+       else checkZero (idx + 1)
+
+   // Step 16 - 19. Recall that `Index15` is the value of `Index` at Step 15.
+   h20 = if (checkZero Index15) then split h15
+       else error "non-zero entries padding indexes"
+
+/**
+ * Verify that `HintBitUnpack` is the reverse of `HintBitPack`.
+ * ```repl
+ * :check HintPackingInverts
+ * ```
+ */
+property HintPackingInverts h = sum (map toInteger (join (map groupBy`{1} h))) < `ω ==>
+   HintBitUnpack (HintBitPack h) == h
 
 /**
  * Sample a polynomial in the ring `Tq`.


### PR DESCRIPTION
Closes #184.

The commit history is a little messy. I wrote the unpack function with `error`s, then totally refactored it to use `Option`s, then had to fix a few bugs -- flagging this because it might make a commit-by-commit review more laborious than it needs to be. I also added some `OptionUtil`s that I ended up not using. Happy to modify the commit history to be a bit sleeker and/or remove the option utils entirely.