### PR TITLE
ML-DSA: Add conversion functions

### DIFF
--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -202,6 +202,19 @@ BitsToIntegersInverts : {α} (fin α, α > 0) => [α] -> Bit
 property BitsToIntegersInverts x = IntegerToBits (BitsToInteger x) == x
 
 /**
+ * Compute a base-256 representation of `x mod 256^α` using little-endian byte
+ * order.
+ * [FIPS-204] Section 7.1, Algorithm 11.
+ */
+IntegerToBytes : {α} (fin α, α > 0) => Integer -> [α]Byte
+IntegerToBytes x = y where
+    // Step 3. Compute the value of `x'` at each iteration of the loop.
+    xs' = [x] # [x' / 256 | x' <- xs']
+
+    // Step 2, 4.
+    y = [fromInteger (x' % 256) | x' <- xs' | i <- [0..α - 1]]
+
+/**
  * Generate an element in the integers mod `q` or a failure indicator.
  * [FIPS-204] Section 7.1, Algorithm 14.
  */

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -208,11 +208,11 @@ property BitsToIntegersInverts x = IntegerToBits (BitsToInteger x) == x
  */
 IntegerToBytes : {α} (fin α, α > 0) => Integer -> [α]Byte
 IntegerToBytes x = y where
-    // Step 3. Compute the value of `x'` at each iteration of the loop.
-    xs' = [x] # [x' / 256 | x' <- xs']
-
-    // Step 2, 4.
+    // Step 2 - 3.
     y = [fromInteger (x' % 256) | x' <- xs' | i <- [0..α - 1]]
+
+    // Step 4. Compute the value of `x'` at each iteration of the loop.
+    xs' = [x] # [x' / 256 | x' <- xs']
 
 /**
  * Convert a bit string into a byte string using little-endian order.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -155,6 +155,24 @@ type d = 13
 type β = η * τ
 
 /**
+ * Compute a base-2 representation of the input mod `2^α` using little-endian
+ * order.
+ * [FIPS-204] Section 7.1, Algorithm 9.
+ */
+IntegerToBits : {α} (fin α, α > 0) => Integer -> [α]
+IntegerToBits x = y' where
+    // Step 3. Compute the value of each `y_i`.
+    y = [x' % 2 | x' <- xs' | i <- [0..α - 1]]
+
+    // Step 4. Compute value of `x'` at each iteration of the loop.
+    // In Cryptol, integer division takes the floor by default.
+    xs' = [x] # [x' / 2 | x' <- xs']
+
+    // Cryptol-specific conversion: convert each Integer-typed bit to an actual
+    // bit and join into a single vector.
+    y' = join [(fromInteger yi) : [1] | yi <- y]
+
+/**
  * Generate an element in the integers mod `q` or a failure indicator.
  * [FIPS-204] Section 7.1, Algorithm 14.
  */

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -215,6 +215,76 @@ IntegerToBytes x = y where
     y = [fromInteger (x' % 256) | x' <- xs' | i <- [0..α - 1]]
 
 /**
+ * Convert a bit string into a byte string using little-endian order.
+ * [FIPS-204] Section 7.1, Algorithm 12.
+ */
+BitsToBytes : {α} (fin α) => [α]Bit -> [α /^ 8]Byte
+BitsToBytes y
+    // A zero-length input will produce a zero-length output.
+    | α == 0 => zero
+    | α > 0 => z where
+        // Compute the values of `y[i]` and `i` at each iteration of the loop.
+        // To simplify the next step, this also:
+        // - Groups the `y[i]` bits into sets of 8 for each `z[⌊i / 8⌋]`, and
+        // - Pads each bit of `y[i]` into a byte to support subsequent operations.
+        y' = groupBy`{8} ([(zext [yi], i)
+            | yi <- y
+            | i <- [0..α - 1]] # zero)
+
+        // Steps 2 - 4. We compute the `y` terms separately then `sum` them
+        // for each byte in `z`.
+        z = [sum [yi * (2 ^^ (i % 8))
+                | (yi, i) <- yi8]
+            | yi8 <- y']
+
+/**
+ * Convert a byte string into a bit string using little-endian order.
+ * [FIPS-204] Section 7.1, Algorithm 13.
+ */
+BytesToBits : {α} (fin α) => [α]Byte -> [8 * α]Bit
+BytesToBits z
+    | α == 0 => []
+    | α > 0 => join [[ y8ij where
+            // Step 4. Taking the last bit is the same as modding by 2. (See
+            // `mod2IsFinalBit`).
+            y8ij = zi' ! 0
+            // Step 5. Shifting right is the same as the iterative
+            // division (see `div2IsShiftR`). This accounts for all the
+            // divisions "up to this point" (e.g. none when `j = 0`), which
+            // is why we use `zi'` to evaluate `y8ij` above.
+            zi' = zi >> j
+        // Step 3.
+        | j <- [0..7]]
+        // Step 2. We iterate over `z` directly instead of indexing into it.
+        | zi <- z ]
+
+private
+    /**
+     * The iterative division by 2 in `BytesToBits` is the same as shifting
+     * right.
+     * ```repl
+     * :prove div2IsShiftR
+     * ```
+     */
+    div2IsShiftR : Byte -> Bit
+    div2IsShiftR C = take (d2 C) == shl where
+        // Note: division here is floor'd by default.
+        d2 c = [c] # d2 (c / 2)
+        shl = [C >> j | j <- [0..7]]
+
+/**
+ * The conversions between bits and bytes are each others' inverses, for
+ * lengths that are a multiple of 8.
+ * This isn't explicit in the spec, but we include the property anyway.
+ * ```repl
+ * :prove B2B2BInverts`{320}
+ * :prove B2B2BInverts`{32 * 44}
+ * ```
+ */
+B2B2BInverts : {α} (fin α) => [8 * α] -> Bit
+property B2B2BInverts y = BytesToBits (BitsToBytes y) == y
+
+/**
  * Generate an element in the integers mod `q` or a failure indicator.
  * [FIPS-204] Section 7.1, Algorithm 14.
  */

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -173,6 +173,35 @@ IntegerToBits x = y' where
     y' = join [(fromInteger yi) : [1] | yi <- y]
 
 /**
+ * Compute the integer value expressed by a bit string using little-endian
+ * order.
+ * [FIPS-204] Section 7.1, Algorithm 10.
+ */
+BitsToInteger : {α} (fin α, α > 0) => [α] -> Integer
+BitsToInteger y = xs ! 0 where
+    // Cryptol-specific conversion: separate the input into α 1-bit vectors,
+    // then convert each to an integer.
+    y' = map toInteger (split`{α} y)
+
+    // Steps 1 - 4. Compute the value of `x` at each iteration of the loop.
+    xs = [0] # [2 * x + y' @ (`α - i)
+        | x <- xs
+        | i <- [1..α]]
+
+/**
+ * The integer / bit conversion functions must invert each other.
+ * This is not explicit in the spec, but we define the property anyway.
+ * The parameter choices are approximately the same as some of the use cases
+ * in the spec.
+ * ```repl
+ * :check BitsToIntegersInverts`{44}
+ * :exhaust BitsToIntegersInverts`{10}
+ * ```
+ */
+BitsToIntegersInverts : {α} (fin α, α > 0) => [α] -> Bit
+property BitsToIntegersInverts x = IntegerToBits (BitsToInteger x) == x
+
+/**
  * Generate an element in the integers mod `q` or a failure indicator.
  * [FIPS-204] Section 7.1, Algorithm 14.
  */


### PR DESCRIPTION
Closes #181.

This adds the conversion functions between bits, bytes, and integers from the spec. 