### PR TITLE
Add naive NTT and NTT arithmetic

### DIFF
--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -1271,6 +1271,23 @@ AddNTT a b = c where
 property addNTTisPlus a b = AddNTT a b == a + b
 
 /**
+ * Compute the product of two elements in `Tq`.
+ * [FIPS-204] Section 7.6, Algorithm 45.
+ */
+MultiplyNTT : Tq -> Tq -> Tq
+MultiplyNTT a b = c where
+    c = [a@i * b@i | i <- [0..255]]
+
+/**
+ * The definition of multiplication in the spec is the same as the built-in
+ * multiplication (*) operator in Cryptol!
+ * ```repl
+ * :prove multiplyNTTisStar
+ * ```
+ */
+property multiplyNTTisStar a b = MultiplyNTT a b == a * b
+
+/**
  * Compute the sum of two vectors over `Tq`
  * [FIPS-204] Section 7.6, Algorithm 46.
  */
@@ -1289,3 +1306,38 @@ AddVectorNTT v w = u where
  */
 addVectorNTTisPlus : {r} (fin r, r > 0) => [r]Tq -> [r]Tq -> Bit
 property addVectorNTTisPlus v w = AddVectorNTT v w == v + w
+
+/**
+ * Compute the product of a scalar and a vector over `Tq`.
+ * [FIPS-204] Section 7.6, Algorithm 47.
+ */
+ScalarVectorNTT : {l} (fin l, l > 0) => Tq -> [l]Tq -> [l]Tq
+ScalarVectorNTT c v = w where
+    w = [MultiplyNTT c (v@i) | i <- [0..l-1]]
+
+/**
+ * Custom operator for computing the product of a scalar and a vector.
+ *
+ * The spec overloads the ring operator `∘` to mean several operations,
+ * in `Tq`, including the product of two elements, the product of a scalar
+ * and a vector, and the product of a matrix and a vector.
+ * Cryptol does not support user-defined overloaded symbols, so we define
+ * `∘` to be the function with the most usage in the spec.
+ *
+ * This implements a more efficient version of `ScalarVectorNTT`.
+ */
+(∘) : {l} (fin l, l > 0) => Tq -> [l]Tq -> [l]Tq
+(∘) c v = [c * vi | vi <- v]
+
+/**
+ * The optimized scalar vector multiplication operator `∘` is equivalent to
+ * `ScalarVectorNTT`.
+ *
+ * These parameters are the only ones used for this operation in the spec:
+ * ```repl
+ * :prove ringIsScalarVectorNTT`{k}
+ * :prove ringIsScalarVectorNTT`{ell}
+ * ```
+ */
+ringIsScalarVectorNTT : {l} (fin l, l > 0) => Tq -> [l]Tq -> Bit
+property ringIsScalarVectorNTT c v = c ∘ v == ScalarVectorNTT c v

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -13,6 +13,10 @@
  *     D.C.), Federal Information Processing Standards Publication (FIPS) NIST
  *     FIPS 204. August 2024.
  *     @see https://doi.org/10.6028/NIST.FIPS.204
+ * [NTT-Guide]: Ardianto Satriawan, Rella Mareta, and Hanho Lee. A Complete
+ *     Beginner Guide to the Number Theoretic Transform (NTT). Cryptology
+ *     ePrint Archive. 2024.
+ *     @see https://eprint.iacr.org/2024/585.pdf
  *
  * @copyright Galois Inc
  * @author Marcella Hastings <marcella@galois.com>
@@ -245,7 +249,8 @@ parameter
  * A 512th root of unity in `Z_q`.
  * [FIPS-204] Section 4, Table 1.
  */
-type ζ = 1753
+ζ : Z q
+ζ = 1753
 
 /**
  * Number of dropped bits from `t` (this compresses the public key for
@@ -1181,3 +1186,69 @@ private
         inRange r1 = (0 <= r1) && (r1 <= (`q - 1) / (2 * `γ2))
         // Apply check coefficientwise to the polynomial vector.
         r1InRange = and [and (map inRange r1s) | r1s <- r1_vec]
+
+/**
+ * Number theoretic transform: compute the "NTT representation" in
+ * `T_q` of a polynomial in `R_q`.
+ *
+ * This is equivalent to [FIPS-204] Section 7.5, Algorithm 41. That particular
+ * formulation is difficult to implement in Cryptol. Instead, we use the naive
+ * NTT implementation described in [NTT-Guide] Section 3.3.2, Equation 16. Note
+ * that [NTT-Guide] uses different notation: their `ψ` is our `ζ`; their `a`
+ * is our `f`; and we set their `n = 256`.
+ *
+ * @design Marcella Hastings <marcella@galois.com>: This is neither efficient
+ * nor obviously spec-adherent. We should aim to make it at least one of those.
+ * Ideally we will consolidate all the NTT implementations across the cryptol-
+ * specs repo into a single common, validated (by some means...) implementation
+ * and import it for use here and elsewhere.
+ * @see https://github.com/GaloisInc/cryptol-specs/issues/163
+ */
+NTT : Rq -> Tq
+NTT f = [f_hat_j j | j <- [0..255]] where
+    f_hat_j j = sum [ (ζ ^^ (2 * i * j + i)) * fi | i <- [0..255] | fi <- f]
+
+/**
+ * Inverse of the number theoretic transform: converts from the "NTT
+ * representation" in `T_q` to a polynomial in `R_q`.
+ *
+ * This is equivalent to [FIPS-204] Section 7.5, Algorithm 42. That particular
+ * formulation is difficult to implement in Cryptol. Instead, we use the naive
+ * NTT implementation described in [NTT-Guide] Section 3.3.3, Equation 18. Note
+ * that [NTT-Guide] uses different notation: their `ψ` is our `ζ`; their `a`
+ * is our `f`; and we set their `n = 256`.
+ *
+ * @design Marcella Hastings <marcella@galois.com>: This is neither efficient
+ * nor obviously spec-adherent. We should aim to make it at least one of those.
+ * Ideally we will consolidate all the NTT implementations across the cryptol-
+ * specs repo into a single common, validated (by some means...) implementation
+ * and import it for use here and elsewhere.
+ * @see https://github.com/GaloisInc/cryptol-specs/issues/163
+ */
+NTTInv : Tq -> Rq
+NTTInv f_hat = [f_i j * inv_root | j <- [0..255]] where
+    inv_root = recip 256 : Z q
+    inv_ζ = recip ζ
+    f_i j = sum [ (inv_ζ ^^ (2 * i * j + j)) * f_hat_j | i <- [0..255] | f_hat_j <- f_hat]
+
+private
+    /**
+     * This property demonstrates that `NTTInv` inverts `NTT`.
+     * ```repl
+     * :set tests=20
+     * :check NTT_Inverts
+     * ```
+     * Alternately, this proves in ~8 min with Z3 v4.13.3.
+     */
+    NTT_Inverts : Rq -> Bit
+    property NTT_Inverts f =  NTTInv (NTT f) == f
+
+    /**
+     * This property demonstrates that `NTT` inverts `NTTInv`.
+     * ```repl
+     * :set tests=20
+     * :check NTTInv_Inverts
+     * ```
+     */
+    NTTInv_Inverts : Tq -> Bit
+    property NTTInv_Inverts f =  NTT (NTTInv f) == f

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -1341,3 +1341,46 @@ ScalarVectorNTT c v = w where
  */
 ringIsScalarVectorNTT : {l} (fin l, l > 0) => Tq -> [l]Tq -> Bit
 property ringIsScalarVectorNTT c v = c ∘ v == ScalarVectorNTT c v
+
+/**
+ * Compute the product of a matrix and a vector over `Tq`.
+ * [FIPS-204] Section 7.6, Algorithm 48.
+ *
+ * Note: The spec defines this operation for a matrix with dimensions
+ * `k x ell`, where `k` and `ell` are natural numbers. This actually overloads
+ * those names, since they're also the dimensions that are part of the
+ * parameterization of the algorithm. In fact, we only ever use this
+ * function for the matrix `A_hat` with dimensions `k x ell` (the parameters).
+ * So, this isn't implemented over arbitrary matrix dimensions, although I
+ * think it could be.
+ */
+MatrixVectorNTT : [k][ell]Tq -> [ell]Tq -> [k]Tq
+MatrixVectorNTT M v = w where
+    // We use the `sum` built-in function instead of iteratively applying
+    // `AddNTT`. See `addNTTisPlus` property for the equivalence.
+    w = [sum [ MultiplyNTT (M@i@j) (v@j)
+        | j <- [0..ell-1]]
+        | i <- [0..k-1] ]
+
+/**
+ * Custom operator for computing the product of a matrix and a vector.
+ *
+ * The spec overloads the ring operator `∘` to mean several operations in
+ * `Tq`. In this executable spec, we define `∘` to mean scalar-vector
+ * multiplication. Cryptol does not support user-defined overloaded symbols,
+ * but for readability, it's nice to have an infix operator for this function.
+ *
+ * This implements a more efficient verison of `ScalarVectorNTT`.
+ */
+(∘∘) : [k][ell]Tq -> [ell]Tq -> [k]Tq
+(∘∘) M v = [sum [Mij * vj | Mij <- Mi | vj <- v] | Mi <- M]
+
+/**
+ * The optimized matrix vector multiplication operator `∘∘` is equivalent to
+ * `MatrixVectorNTT`.
+ * ```repl
+ * :prove doubleRingIsMatrixVectorNTT
+ * ```
+ */
+doubleRingIsMatrixVectorNTT : [k][ell]Tq -> [ell]Tq -> Bit
+property doubleRingIsMatrixVectorNTT M v = (M ∘∘ v) == MatrixVectorNTT M v

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -121,6 +121,18 @@ property modPlusMinusWorks m = inRange && congruent where
     congruent = ((fromZ m) % `α) == (m' % `α)
 
 /**
+ * Apply `NTT` and `NTTInv` entry-wise over a vector of polynomials.
+ * [FIPS-204] Section 2.5.
+ *
+ * The spec overloads the names `NTT` and `NTTInv` for both the single
+ * application to a polynomial in `Rq` and the vector application to every
+ * entry in a vector. Since Cryptol does not support user-defined overloaded
+ * names, we define the following functions.
+ */
+NTT_Vec = map NTT
+NTTInv_Vec = map NTT
+
+/**
  * Wrapper function around SHAKE256, specifying the length `l` in bytes.
  * [FIPS-204] Section 3.7.
  *

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -1252,3 +1252,40 @@ private
      */
     NTTInv_Inverts : Tq -> Bit
     property NTTInv_Inverts f =  NTT (NTTInv f) == f
+
+/**
+ * Compute the sum of two elemetns in `Tq`.
+ * [FIPS-204] Section 7.6, Algorithm 44.
+ */
+AddNTT : Tq -> Tq -> Tq
+AddNTT a b = c where
+    c = [a@i + b@i | i <- [0..255]]
+
+/**
+ * The definition of addition in the spec is the same as the built-in addition
+ * operator in Cryptol!
+ * ```repl
+ * :prove addNTTisPlus
+ * ```
+ */
+property addNTTisPlus a b = AddNTT a b == a + b
+
+/**
+ * Compute the sum of two vectors over `Tq`
+ * [FIPS-204] Section 7.6, Algorithm 46.
+ */
+AddVectorNTT : {l} (fin l, l > 0) => [l]Tq -> [l]Tq -> [l]Tq
+AddVectorNTT v w = u where
+    u = [AddNTT (v@i) (w@i) | i <- [0..l-1]]
+
+/**
+ * The defintion of vector addition in the spec is the same as the built-in
+ * addition operator in Cryptol!
+ * There's only one NTT vector addition that I could find in the spec and it's
+ * between vectors of length `k`:
+ * ```repl
+ * :prove addVectorNTTisPlus`{k}
+ * ```
+ */
+addVectorNTTisPlus : {r} (fin r, r > 0) => [r]Tq -> [r]Tq -> Bit
+property addVectorNTTisPlus v w = AddVectorNTT v w == v + w


### PR DESCRIPTION
Closes #191.

This adds a naive NTT implementation, with citations for its provenance, and some arithmetic over NTT polynomials. I reviewed the spec and added two custom infix operators for the operations that are actually called elsewhere. 