### PR TITLE
ML-DSA: Add sign_internal

### DIFF
--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -121,6 +121,30 @@ property modPlusMinusWorks m = inRange && congruent where
     congruent = ((fromZ m) % `α) == (m' % `α)
 
 /**
+ * Compute the infinity norm over a list of elements in `Rq`.
+ * [FIPS-204] Section 2.3, "‖⋅‖∞".
+ */
+infNormRq : {m} (fin m) => [m]Rq -> Integer
+infNormRq w = maxList [ maxList [ abs (modPlusMinus`{q} wij)
+    | wij <- wi]
+    | wi <- w]
+
+/**
+ * Compute the infinity norm over a list of elements in `R`.
+ * [FIPS-204] Section 2.3, "‖⋅‖∞".
+ */
+infNormR : {m} (fin m) => [m]R -> Integer
+infNormR w = maxList [ maxList [ abs wij | wij <- wi] | wi <- w]
+
+private
+    /**
+     * Compute the max of a list of non-negative elements, as in
+     * [FIPS-204] Section 2.3, "‖⋅‖∞".
+     */
+    maxList : {n, a} (fin n, Literal 0 a, Cmp a) => [n]a -> a
+    maxList list = foldl max 0 list
+
+/**
  * Apply `NTT` and `NTTInv` entry-wise over a vector of polynomials.
  * [FIPS-204] Section 2.5.
  *

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -177,6 +177,15 @@ H : {l, m} (fin m) => [m][8] -> [l][8]
 H str = SHAKE256::xofBytes`{8 * l} str
 
 /**
+ * Wrapper function around SHAKE256 that takes bit strings as input.
+ * [FIPS-204] Section 3.7.
+ *
+ *
+ */
+HBits : {l, m} (fin m) => [m] -> [l][8]
+HBits str = split (SHAKE256::xof`{8 * l} (str))
+
+/**
  * Wrapper function around SHAKE128, specifying the length `l` in bytes.
  * [FIPS-204] Section 3.7.
  *
@@ -308,7 +317,7 @@ type d = 13
  * determine if a candidate signature is valid.
  * [FIPS-204] Section 4, Table 1.
  */
-type β = η * τ
+β = `(η * τ) : Integer
 
 /**
  * Generate a public-private key pair from a seed.
@@ -342,12 +351,51 @@ KeyGen_internal ξ = (pk, sk) where
 
 
 Sign_internal : {m} (fin m) => PrivateKey -> [m] -> [32]Byte -> Signature
-Sign_internal sk M' rnd = undefined where
+Sign_internal sk M' rnd = σ where
     (rho, K, tr, s1, s2, t0) = skDecode sk
 
     s1_hat = NTT_Vec (castToRq s1)
     s2_hat = NTT_Vec (castToRq s2)
     t0_hat = NTT_Vec (castToRq t0)
+    A_hat = ExpandA rho
+
+    // TODO: explain why we `join` instead of `BytesToBits`ing here.
+    mu = HBits`{64} (join tr # M')
+    rho''= H`{64} (K # rnd # mu)
+
+    kappa0 = 0
+
+    rejection_sample: Integer -> ([λ / 4]Byte, ([ell]Rq, [k]R2))
+    rejection_sample kappa = case maybe_zh of
+            Some zh -> (c_til, zh)
+            None -> rejection_sample (kappa + `ell)
+        where
+            y = castToRq (ExpandMask rho'' kappa)
+            w = NTTInv_Vec (A_hat ∘∘ (NTT_Vec y))
+            w1 = HighBits w
+            c_til = H`{λ / 4} (mu # w1Encode w1)
+            [c] = castToRq [(SampleInBall c_til)]
+            c_hat = NTT c
+            cs1 = NTTInv_Vec (c_hat ∘ s1_hat)
+            cs2 = NTTInv_Vec (c_hat ∘ s2_hat)
+            z = y + cs1
+            r0 = LowBits (w - cs2)
+            maybe_zh = if (infNormRq z >= `γ1 - β) || (infNormR r0 >= `γ2 - β) then
+                    None
+                else maybe_zh' where
+                    ct0 = NTTInv_Vec (c_hat ∘ t0_hat)
+                    h = MakeHint (-ct0) (w - cs2 + ct0)
+                    maybe_zh' = if (infNormRq ct0 >= `γ2) || (numberOf1sInh > `ω)
+                        then None
+                        else Some (z, h)
+                    numberOf1sInh = sum [if b then 1 else 0 | b <- join h]
+
+    (c_tilFinal, (zFinal, hFinal)) = rejection_sample kappa0
+
+    modPlusMinus_Vec v = [map modPlusMinus`{q} vi | vi <- v]
+
+    σ = sigEncode c_tilFinal (modPlusMinus_Vec zFinal) hFinal
+
 /**
  * Compute a base-2 representation of the input mod `2^α` using little-endian
  * order.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -350,50 +350,66 @@ KeyGen_internal ξ = (pk, sk) where
     sk = skEncode ρ K tr s1 s2 t0
 
 
+/**
+ * Deterministic algorithm to generate a signature for a formatted message `M'`.
+ * [FIPS-204] Section 6.2, Algorithm 7.
+ */
 Sign_internal : {m} (fin m) => PrivateKey -> [m] -> [32]Byte -> Signature
 Sign_internal sk M' rnd = σ where
-    (rho, K, tr, s1, s2, t0) = skDecode sk
+    // Step 1.
+    (ρ, K, tr, s1, s2, t0) = skDecode sk
 
+    // Steps 2 - 5.
     s1_hat = NTT_Vec (castToRq s1)
     s2_hat = NTT_Vec (castToRq s2)
     t0_hat = NTT_Vec (castToRq t0)
-    A_hat = ExpandA rho
+    A_hat = ExpandA ρ
 
-    // TODO: explain why we `join` instead of `BytesToBits`ing here.
-    mu = HBits`{64} (join tr # M')
-    rho''= H`{64} (K # rnd # mu)
+    // Step 6. The endianness does not align with the spec here -- we had to
+    // use `join` instead of `BytesToBits`ing here.
+    μ = HBits`{64} (join tr # M')
 
-    kappa0 = 0
+    // Step 7.
+    ρ''= H`{64} (K # rnd # μ)
 
+    // Steps 10 - 32. The rejection sampling loop in the spec is implemented
+    // here using recursion.
     rejection_sample: Integer -> ([λ / 4]Byte, ([ell]Rq, [k]R2))
-    rejection_sample kappa = case maybe_zh of
+    rejection_sample κ = case maybe_zh of
             Some zh -> (c_til, zh)
-            None -> rejection_sample (kappa + `ell)
+            None -> rejection_sample (κ + `ell)
         where
-            y = castToRq (ExpandMask rho'' kappa)
+            y = castToRq (ExpandMask ρ'' κ)
             w = NTTInv_Vec (A_hat ∘∘ (NTT_Vec y))
             w1 = HighBits w
-            c_til = H`{λ / 4} (mu # w1Encode w1)
+            c_til = H`{λ / 4} (μ # w1Encode w1)
             [c] = castToRq [(SampleInBall c_til)]
             c_hat = NTT c
             cs1 = NTTInv_Vec (c_hat ∘ s1_hat)
             cs2 = NTTInv_Vec (c_hat ∘ s2_hat)
             z = y + cs1
             r0 = LowBits (w - cs2)
-            maybe_zh = if (infNormRq z >= `γ1 - β) || (infNormR r0 >= `γ2 - β) then
-                    None
+            maybe_zh = if (infNormRq z >= `γ1 - β) || (infNormR r0 >= `γ2 - β)
+                then None
                 else maybe_zh' where
                     ct0 = NTTInv_Vec (c_hat ∘ t0_hat)
                     h = MakeHint (-ct0) (w - cs2 + ct0)
-                    maybe_zh' = if (infNormRq ct0 >= `γ2) || (numberOf1sInh > `ω)
+                    maybe_zh' =
+                        if (infNormRq ct0 >= `γ2) || (numberOf1sInh > `ω)
                         then None
                         else Some (z, h)
+
+                    // Compute the number of 1s in the hint by converting each
+                    // bit to an integer and summing them.
                     numberOf1sInh = sum [if b then 1 else 0 | b <- join h]
 
-    (c_tilFinal, (zFinal, hFinal)) = rejection_sample kappa0
+    // Step 8 - 32.
+    (c_tilFinal, (zFinal, hFinal)) = rejection_sample 0
 
+    // In Step 33, `modPlusMinus` is applied componentwise to the vector `z`.
     modPlusMinus_Vec v = [map modPlusMinus`{q} vi | vi <- v]
 
+    // Step 33.
     σ = sigEncode c_tilFinal (modPlusMinus_Vec zFinal) hFinal
 
 /**

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -136,6 +136,14 @@ infNormRq w = maxList [ maxList [ abs (modPlusMinus`{q} wij)
 infNormR : {m} (fin m) => [m]R -> Integer
 infNormR w = maxList [ maxList [ abs wij | wij <- wi] | wi <- w]
 
+/**
+ * Typecasts elements in `R` to `Rq` by taking the unique congruence class
+ * modulo `q` tht contains each coefficient.
+ * [FIPS-204] Section 2.4.1.
+ */
+castToRq : {m} (fin m) => [m]R -> [m]Rq
+castToRq v = [map fromInteger vi | vi <- v]
+
 private
     /**
      * Compute the max of a list of non-negative elements, as in
@@ -317,8 +325,9 @@ KeyGen_internal ξ = (pk, sk) where
     (s1, s2) = ExpandS ρ'
 
     // Explicitly typecast vectors in `R` to `Rq`.
-    s1' = [map fromInteger s1_i | s1_i <- s1]
-    s2' = [map fromInteger s2_i | s2_i <- s2]
+    s1' = castToRq s1
+    s2' = castToRq s2
+
     // Step 5.
     t = NTTInv_Vec (A_hat ∘∘ NTT_Vec s1') + s2'
     // Step 6.
@@ -331,6 +340,14 @@ KeyGen_internal ξ = (pk, sk) where
     // Step 10.
     sk = skEncode ρ K tr s1 s2 t0
 
+
+Sign_internal : {m} (fin m) => PrivateKey -> [m] -> [32]Byte -> Signature
+Sign_internal sk M' rnd = undefined where
+    (rho, K, tr, s1, s2, t0) = skDecode sk
+
+    s1_hat = NTT_Vec (castToRq s1)
+    s2_hat = NTT_Vec (castToRq s2)
+    t0_hat = NTT_Vec (castToRq t0)
 /**
  * Compute a base-2 representation of the input mod `2^α` using little-endian
  * order.

--- a/Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_44.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_44.cry
@@ -17,14 +17,18 @@ import Primitive::Asymmetric::Signature::ML_DSA::Instantiations::ML_DSA_44 as ML
  * Test function for running a KAT from [PQC-KAT] in the "deterministic, raw"
  * category.
  *
- * "Deterministic" categorizes how the signing seeds `ρ'` are computed.
+ * "Deterministic" categorizes the per-message randomness parameter `rnd` for
+ * `Sign_internal` -- in this case, it is zero.
  * "Raw" categorizes the set of functions being tested -- in this case, the
  * `{KeyGen, Sign, Verify}_internal` functions. See [PQC-KAT] README.md for
  * more details.
  */
-tryDetKAT xi expected_pk expected_sk = keygenWorks where
+tryDetKAT xi expected_pk expected_sk msg expected_sig = signWorks where
     (pk, sk) = ML_DSA::KeyGen_internal xi
     keygenWorks = (pk == expected_pk) && (sk == expected_sk)
+
+    sig = ML_DSA::Sign_internal expected_sk msg zero
+    signWorks = expected_sig == (sig # (split msg))
 
 /**
  * Test the raw, deterministic KAT with count 0.
@@ -32,7 +36,7 @@ tryDetKAT xi expected_pk expected_sk = keygenWorks where
  * :prove det0
  * ```
  */
-property det0 = tryDetKAT xi pk sk where
+property det0 = tryDetKAT xi pk sk msg sm where
     xi = split 0xf696484048ec21f96cf50a56d0759c448f3779752f0383d37449690694cf7a68
     seed = join [
         0x23f1c88bd0e65f2c891ce865bd3275a7ffdbe4f9036e75b9,
@@ -165,7 +169,7 @@ property det0 = tryDetKAT xi pk sk where
     ])
     msg = 0x6dbbc4375136df3b07f7c70e639e223e
     mlen = 16
-    sm = join [
+    sm = split (join [
         0xa8bb75e2f0902b5a2330d586ac172f8a09f66d9b83867b705dbb40c8d032df0e,
         0x56029a5b7a6701b50bd9f0c28a9d1cf0f64c2f3e01d6cbd7fd358c2de8d34de1,
         0x328693586ee45861b3142a80f9e2039bc53719bdead3ed17c760770c8c542154,
@@ -242,5 +246,5 @@ property det0 = tryDetKAT xi pk sk where
         0x090e32537987888f92959e9fb5cacdf2fd020d1f48556168696a72a0a5addce8,
         0xeefcfe1b275b7b829daeafc1c4d1de193e43474e4f6e7f96adb7bfd200000000,
         0x0000000000000000000000000000000011232f3c6dbbc4375136df3b07f7c70e
-    ] # 0x639e223e
+    ] # 0x639e223e)
     smlen = 2436


### PR DESCRIPTION
Addresses part of #192.

This adds `Sign_internal` and several other utility functions that weren't implemented yet. There is one weird thing with endianness happening -- I'll start a discussion inline. 

Chaining this with #209 since it needs the correct NTT implementations to work.