### PR TITLE
HMAC: put implementations together

### DIFF
--- a/Primitive/Keyless/Hash/README.md
+++ b/Primitive/Keyless/Hash/README.md
@@ -5,7 +5,7 @@ This directory includes executable specifications for several hash functions.
 There are two versions of SHA2 here, as defined in [FIPS 180-4](https://doi.org/10.6028/NIST.FIPS.180-4). The [`SHA2`](/Primitive/Keyless/Hash/SHA2/) directory contains the spec-adherent version and should be used for the vast majority of applications.
 
 The [`SHA2Internal`](/Primitive/Keyless/Hash/SHA2Internal/) directory contains an equivalent implementation. It was originally written as part of a proof of correctness for a Java implementation of SHA2. It makes public several internal components of SHA2, like the compression function and the state representation, that are not part of the public interface defined in FIPS 180-4.
-These are used in the implementation of several other algorithms in this repo, like [HMAC](/Primitive/Keyless/Hash/HMAC.cry) and [SHACAL](/Primitive/Symmetric/Cipher/Block/SHACAL.cry). We've kept the two instantiations that these dependencies use and [checked equivalence of the two versions](SHA2Internal/Equivalence.cry) but recommend using the spec-adherent version where possible.
+These are used in the implementation of several other algorithms in this repo, like [HMAC](/Primitive/Symmetric/MAC/HMAC_SHA384.cry) and [SHACAL](/Primitive/Symmetric/Cipher/Block/SHACAL.cry). We've kept the two instantiations that these dependencies use and [checked equivalence of the two versions](SHA2Internal/Equivalence.cry) but recommend using the spec-adherent version where possible.
 
 ## SHA3
 The SHA3 specification includes one internal algorithm, known as [Keccak](Keccak.cry), and two families of public interfaces: the hash functions [SHA3](SHA3/) and the extendable-output functions [SHAKE](SHAKE/).

--- a/Primitive/Symmetric/KDF/HKDF256.cry
+++ b/Primitive/Symmetric/KDF/HKDF256.cry
@@ -4,7 +4,7 @@
  */
 module Primitive::Symmetric::KDF::HKDF256 = Primitive::Symmetric::KDF::HKDF where
 
-import Primitive::Symmetric::MAC::HMAC
+import Primitive::Symmetric::MAC::HMAC_SHA256
 
 type HashLen = 32
 HMAC = hmacBytes

--- a/Primitive/Symmetric/MAC/HMAC_SHA256.cry
+++ b/Primitive/Symmetric/MAC/HMAC_SHA256.cry
@@ -1,11 +1,11 @@
 /*
-@copyright Galois, Inc. 2016-2018
-@author Aaron Tomb <atomb@galois.com>
-@author Nathan Collins <conathan@galois.com>
-@author Joey Dodds <jdodds@galois.com>
-*/
+ * @copyright Galois, Inc. 2016-2018
+ * @author Aaron Tomb <atomb@galois.com>
+ * @author Nathan Collins <conathan@galois.com>
+ * @author Joey Dodds <jdodds@galois.com>
+ */
 
-module Primitive::Symmetric::MAC::HMAC where
+module Primitive::Symmetric::MAC::HMAC_SHA256 where
 
 import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256
 

--- a/Primitive/Symmetric/MAC/HMAC_SHA384.cry
+++ b/Primitive/Symmetric/MAC/HMAC_SHA384.cry
@@ -1,14 +1,11 @@
 /*
-   @copyright Galois Inc. 2020
-   @author Brett Boston
-   www.cryptol.net
-*/
-
-/*
  * This is a simple implementation of HMAC with SHA-384
+ *
+ * @copyright Galois Inc. 2020
+ * @author Brett Boston
+ * www.cryptol.net
  */
-
-module Primitive::Keyless::Hash::HMAC where
+module Primitive::Symmetric::MAC::HMAC_SHA384 where
 
 import Primitive::Keyless::Hash::SHA2Internal::SHA384
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This repo includes the set of cryptographic algorithms specified in [NSA's Suite
 
 There are some [ciphers for authenticated encryption](Primitive/Symmetric/Cipher/Authenticated/) that are commonly used but not formally NIST-approved, like [ChaCha20-Poly1305](Primitive/Symmetric/Cipher/Authenticated/ChaChaPolyCryptolIETF.md) and [AES-GCM-SIV](Primitive/Symmetric/Cipher/Authenticated/AES_GCM_SIV.cry). There are also [many block ciphers](Primitive/Symmetric/Cipher/Block/), including some of historical interest (e.g. [Triple DES](Primitive/Symmetric/Cipher/Block/TripleDES.md)), and a smaller collection of [stream ciphers](Primitive/Symmetric/Cipher/Stream/)
 
-There is an implementation of [HMAC](Primitive/Symmetric/MAC/HMAC.cry) that is used to instantiate [a hash-based key derivation function (HKDF)](Primitive/Symmetric/KDF/).
+There is an implementation of [HMAC](Primitive/Symmetric/MAC/HMAC_SHA256.cry) that is used to instantiate [a hash-based key derivation function (HKDF)](Primitive/Symmetric/KDF/).
 
 There are two members of [the BLAKE family of hash functions](Primitive/Keyless/Hash/), as well as several historical hash functions, like [MD5](Primitive/Keyless/Hash/MD5.md) and [SHA1](Primitive/Keyless/Hash/SHA1.cry), that are not suitable for general use. There's also a version of the standardized [deterministic random bit generator (DRBG)](Primitive/Keyless/Generator/DRBG.cry).
 


### PR DESCRIPTION
Closes #157 

This puts the two HMAC implementations in the same place and makes some minor doc / naming updates.

Chaining it on the SHA2 PR because one of these depends on the internal version, which gets renamed, and it seemed easier to not deal with a rebase or merge conflict later.