### PR TITLE
`ChaChaPolyCryptolIETF`: Return an `Option` in `AEAD_CHACHA20_POLY1305_DECRYPT`

### DIFF
--- a/Common/OptionUtils.cry
+++ b/Common/OptionUtils.cry
@@ -3,6 +3,7 @@
  *
  * @copyright Galois, Inc.
  * @author Marcella Hastings <marcella@galois.com>
+ * @author Ryan Scott <rscott@galois.com>
  */
 module Common::OptionUtils where
 
@@ -22,6 +23,18 @@ optApply : {a, b} (a -> b) -> Option a -> Option b
 optApply f opt = case opt of
     Some x -> Some (f x)
     None -> None
+
+/**
+ * The `optFold` function takes a default value, a function, and an `Option`
+ * value. If the `Option` value is `None`, then return the default value.
+ * Otherwise, apply the function to the value inside the `Some` and return the
+ * result.
+ */
+optFold : {a, b} b -> (a -> b) -> Option a -> b
+optFold def f opt =
+  case opt of
+    Some x -> f x
+    None   -> def
 
 /**
  * Flatten a nested `Option` into a single `Option` that is `Some` only if


### PR DESCRIPTION
Instead of returning `([m][8], Bit)`, where the `Bit` indicates whether the result is valid or not, we now make the `AEAD_CHACHA20_POLY1305_DECRYPT` function return an `Option`. We also introduce an `optFold` function to `Common::OptionUtils` to factor out some repeatedly used code needed to post-process the decrypted results.

This checks off one box in #239.