### PR TITLE
GF28: Update power function

### DIFF
--- a/Common/GF24.cry
+++ b/Common/GF24.cry
@@ -14,13 +14,11 @@ gf24Mult x y = pmod (pmult x y) irreducible
 
 // Define a power of an element in GF24
 gf24Pow : GF24 -> GF24 -> GF24
-gf24Pow n k = pow k
-    where
-        sq x = gf24Mult x x
-        pow i = if i == 0 then 1
-                else if i ! 0
-                     then gf24Mult n (sq (pow (i >> 1)))
-                     else sq (pow (i >> 1))
+gf24Pow n k = vals ! 0 where
+    sq x = gf24Mult x x
+    vals = [1] # [ if i then gf24Mult n (sq acc) else sq acc
+        | acc <- vals
+        | i   <- k]
 
 // Self adding gives zero
 polySelfAdd' : GF24 -> Bit

--- a/Common/GF28.cry
+++ b/Common/GF28.cry
@@ -48,12 +48,11 @@ mult x y = pmod (pmult x y) irreducible
 
 /** A GF28 value to a scalar power */
 pow : GF28 -> [8] -> GF28
-pow n k = pow' k
-  where   sq x  = mult x x
-          pow' i = if i == 0 then 1
-                  else if i ! 0  // if odd
-                       then mult n (sq (pow' (i >> 1)))
-                       else sq (pow' (i >> 1))
+pow n k = vals ! 0 where
+    sq x = mult x x
+    vals = [1] # [ if i then mult n (sq acc) else sq acc
+        | acc <- vals
+        | i   <- k]
 
 /** Dot product of two vectors */
 dotProduct : {n} (fin n) => [n]GF28 -> [n]GF28 -> GF28

--- a/Common/GF28.cry
+++ b/Common/GF28.cry
@@ -1,20 +1,20 @@
-//
-// Implementation of the finite field GF(2^8).
-//
-// @copyright Galois, Inc
-// @author Nichole Schimanski <nls@galois.com>
-// @author Alannah Carr
-// @author Marcella Hastings <marcella@galois.com>
-//
-// This implementation is drawn from the description of the Galois Field
-// GF(2^8) in [FIPS-197u1], Section 4.
-//
-// References
-// [FIPS-197u1]: Morris J. Dworkin, Elaine B. Barker, James R. Nechvatal,
-// James Foti, Lawrence E. Bassham, E. Roback, and James F. Dray Jr.
-// Advanced Encryption Standard (AES). Federal Inf. Process. Stds. (NIST FIPS)
-// 197, update 1. May 2023.
-//
+/**
+ * Implementation of the finite field GF(2^8).
+ *
+ * @copyright Galois, Inc
+ * @author Nichole Schimanski <nls@galois.com>
+ * @author Alannah Carr
+ * @author Marcella Hastings <marcella@galois.com>
+ *
+ * This implementation is drawn from the description of the Galois Field
+ * GF(2^8) in [FIPS-197u1], Section 4.
+ *
+ * References
+ * [FIPS-197u1]: Morris J. Dworkin, Elaine B. Barker, James R. Nechvatal,
+ * James Foti, Lawrence E. Bassham, E. Roback, and James F. Dray Jr.
+ * Advanced Encryption Standard (AES). Federal Inf. Process. Stds. (NIST FIPS)
+ * 197, update 1. May 2023.
+ */
 module Common::GF28 where
 
 /**
@@ -65,10 +65,9 @@ vectorMult v ms = [ dotProduct v m | m <- ms ]
 /**
  * Multiply two matrices. [FIPS-197u1] Section 4.3
  */
-matrixMult : {n, m, k} (fin m)
-              => [n][m]GF28 -> [m][k]GF28 -> [n][k]GF28
+matrixMult : {n, m, k} (fin m) => [n][m]GF28 -> [m][k]GF28 -> [n][k]GF28
 matrixMult xss yss = [ vectorMult xs yss' | xs <- xss ]
-   where yss' = transpose yss
+    where yss' = transpose yss
 
 /**
  * [FIPS-197u1] Section 4.4, Algorithm 4.10
@@ -77,8 +76,8 @@ matrixMult xss yss = [ vectorMult xs yss' | xs <- xss ]
  * ```
  */
 property inverseDefined x =
-  if x == 0 then inverse x == 0
-  else mult x (inverse x) == 1
+    if x == 0 then inverse x == 0
+    else mult x (inverse x) == 1
 
 /**
  * Compute the inverse of a value. [FIPS-197u1 Section 4.4, Algorithm 4.11

--- a/Primitive/Symmetric/Cipher/Block/AES/ExpandKey.cry
+++ b/Primitive/Symmetric/Cipher/Block/AES/ExpandKey.cry
@@ -39,10 +39,35 @@ parameter
 
 /**
  * Key expansion depends on 10 fixed words denoted by `Rcon`.
- * [FIPS-197u1] Table 5.
+ * [FIPS-197u1] Section 5.2, Table 5.
+ *
+ * This function requires `1 <= j <= 10`.
  */
 Rcon : [8] -> [4]GF28
-Rcon j = [ GF28::pow <| x |> (j-1), 0, 0, 0]
+Rcon j = constants @ (j - 1) where
+    constants = [
+        [0x01, 0x00, 0x00, 0x00],
+        [0x02, 0x00, 0x00, 0x00],
+        [0x04, 0x00, 0x00, 0x00],
+        [0x08, 0x00, 0x00, 0x00],
+        [0x10, 0x00, 0x00, 0x00],
+        [0x20, 0x00, 0x00, 0x00],
+        [0x40, 0x00, 0x00, 0x00],
+        [0x80, 0x00, 0x00, 0x00],
+        [0x1b, 0x00, 0x00, 0x00],
+        [0x36, 0x00, 0x00, 0x00]
+    ]
+
+/**
+ * The value of the left-most byte of `Rcon[j]` in polynomial form is `x^(j-1)`.
+ * [FIPS-197u1] Section 5.2.
+ * ```repl
+ * :prove RconIsExponentiation
+ * ```
+ */
+RconIsExponentation : [8] -> Bit
+property RconIsExponentation j = (1 <= j) && (j <= 10) ==>
+    (Rcon j)@0 == GF28::pow <| x |> (j-1)
 
 /**
  * Transformation on words for key expansion.
@@ -56,7 +81,7 @@ RotWord [a0, a1, a2, a3] = [a1, a2, a3, a0]
  * [FIPS-197u1] Equation 5.11.
  */
 SubWord : [4]GF28 -> [4]GF28
-SubWord [a0, a1, a2, a3] = 
+SubWord [a0, a1, a2, a3] =
       [ Sbox::sbox a0, Sbox::sbox a1, Sbox::sbox a2, Sbox::sbox a3 ]
 
 /**


### PR DESCRIPTION
Closes #242 

This replaces the power function in GF28 (and GF24, for good measure) with a non-recursive version. It also updates AES to use that power function in a way better aligned with the spec -- as a sanity check on some constants, rather than in real-time computation.