### PR TITLE
Remove use of Integer in md5

### DIFF
--- a/Primitive/Keyless/Hash/MD5.md
+++ b/Primitive/Keyless/Hash/MD5.md
@@ -194,7 +194,7 @@ T =
 Do the following:
 
 ```cryptol
-round1_op : Buffer -> [32] -> Integer -> [32] -> Buffer
+round1_op : Buffer -> [32] -> [5] -> [32] -> Buffer
 round1_op [a, b, c, d] Xk s Ti = [a', b, c, d]
     where
         a' = b + ((a + (F b c d) + Xk + Ti) <<< s)


### PR DESCRIPTION
Integers are hard to support in some compiler targets and this particular parameter only needs to work with up to 5-bit numbers, as far as I can tell