### PR TITLE
Add cryptol project for Suite B

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+## Generated files from Cryptol projects:
+loadcache.toml
+
 ## Core latex/pdflatex auxiliary files:
 *.aux
 *.lof

--- a/Primitive/Symmetric/Cipher/Block/AES/ExpandKey.cry
+++ b/Primitive/Symmetric/Cipher/Block/AES/ExpandKey.cry
@@ -65,8 +65,8 @@ Rcon j = constants @ (j - 1) where
  * :prove RconIsExponentiation
  * ```
  */
-RconIsExponentation : [8] -> Bit
-property RconIsExponentation j = (1 <= j) && (j <= 10) ==>
+RconIsExponentiation : [8] -> Bit
+property RconIsExponentiation j = (1 <= j) && (j <= 10) ==>
     (Rcon j)@0 == GF28::pow <| x |> (j-1)
 
 /**

--- a/cryproject.toml
+++ b/cryproject.toml
@@ -1,0 +1,36 @@
+# Build and cache the collection of Suite B algorithms.
+modules = [
+    # Elliptic curves for ECDH and ECDSA
+    "Common/EC/PrimeField/Instantiations/*",
+    "Common/EC/PrimeField/Tests/*",
+
+    # ECDH, instantiated with P-curves
+    "Primitive/Asymmetric/KEM/ECDH/Instantiations/*",
+    "Primitive/Asymmetric/KEM/ECDH/Tests/*",
+
+    # ECDSA, instantiated with P-curves and SHA2
+    "Primitive/Asymmetric/Signature/ECDSA/Instantiations/ECDSA_P224_SHA224.cry",
+    "Primitive/Asymmetric/Signature/ECDSA/Instantiations/ECDSA_P256_SHA256.cry",
+    "Primitive/Asymmetric/Signature/ECDSA/Instantiations/ECDSA_P384_SHA384.cry",
+    "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P224_SHA224.cry",
+    "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry",
+    "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry",
+
+    # AES (standalone)
+    "Primitive/Symmetric/Cipher/Block/AES128.cry",
+    "Primitive/Symmetric/Cipher/Block/AES192.cry",
+    "Primitive/Symmetric/Cipher/Block/AES256.cry",
+    "Primitive/Symmetric/Cipher/Block/Tests/TestAES.cry",
+
+    # AES (counter mode)
+    "Primitive/Symmetric/Cipher/Block/Instantiations/AES*_CTR.cry",
+    "Primitive/Symmetric/Cipher/Block/Tests/TestAES_CTR.cry",
+
+    # AES (GCM mode)
+    "Primitive/Symmetric/Cipher/Authenticated/Instantiations/AES*_GCM.cry",
+    "Primitive/Symmetric/Cipher/Authenticated/Tests/*",
+
+    # SHA2
+    "Primitive/Keyless/Hash/SHA2/Instantiations/*",
+    "Primitive/Keyless/Hash/SHA2/Tests/*",
+]

--- a/cryproject.toml
+++ b/cryproject.toml
@@ -1,4 +1,8 @@
 # Build and cache the collection of Suite B algorithms.
+#
+# @copyright Galois, Inc.
+# @author Marcella Hastings <marcella@galois.com>
+#
 modules = [
     # Elliptic curves for ECDH and ECDSA
     "Common/EC/PrimeField/Instantiations/*",

--- a/scripts/check_copyright.sh
+++ b/scripts/check_copyright.sh
@@ -18,7 +18,8 @@ interesting_files() {
         case $fname in
             *README.md) continue ;;
 
-            *.cry | *.tex | *.md | *.bat | *.awk)
+
+            *.cry | *.tex | *.md | *.bat | *.awk | cryproject.toml)
                 echo $fname ;;
         esac
     done


### PR DESCRIPTION
Closes #241.

Adds a `.toml` file with [the Cryptol project definition](https://galoisinc.github.io/cryptol/master/Project.html) for all the algorithms in Suite B, plus a few bonus parameter sets.

In terms of best practices, I did not push the cache here. I figured the project file should exist for reference, but any actual caching should be maintained by CI.

I was thinking about whether it would be nice longer-term to include separate project specifications for different algorithm sets (for example, a `suiteb.cryproject.toml` and a `cnsa2.cryproject.toml`, and maybe another for post-quantum algorithms). I think this would require extending cryptol projects to support multiple caches, named caches, and if we really want to optimize, some kind of shared cache (since e.g. AES is in both Suite B and CNSA 2.0).