### PR TITLE
Fix SHA2 message upper bound off-by-one

### DIFF
--- a/Primitive/Keyless/Hash/SHA2/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA2/Specification.cry
@@ -58,7 +58,7 @@ parameter
  * [FIPS-180-4] Section 1, Figure 1, "Message Size (bits)"
  */
 type MessageUpperBound = 2 * w
-type constraint ValidMessageLength L = width L < MessageUpperBound
+type constraint ValidMessageLength L = width L <= MessageUpperBound
 
 /**
  * Length of the hash digest.


### PR DESCRIPTION
Previously we we slightly too conservative. According to the specification cited on the ValidMessageLength comment we should see SHA256 valid for message lengths <2^64

Observe below how we get the expected behavior now when instantiating `hash` to these boundary sizes.

```
Primitive::Keyless::Hash::SHA2::Instantiations::SHA256> :t hash : [2^^64-1] -> _
(hash : [2 ^^ 64 - 1] -> _) : [18446744073709551615] -> [256]
Primitive::Keyless::Hash::SHA2::Instantiations::SHA256> :t hash : [2^^64-1] -> _
(hash : [2 ^^ 64 - 1] -> _) : [18446744073709551615] -> [256]
Primitive::Keyless::Hash::SHA2::Instantiations::SHA256> :t hash : [2^^64] -> _

[error] at <interactive>:21:4--21:23:
  • Unsolvable constraint:
      MessageUpperBound >= 65
        arising from
        use of expression hash
        at <interactive>:21:4--21:8
```

```
Primitive::Keyless::Hash::SHA2::Instantiations::SHA512> :t hash : [2^^128-1] -> _
(hash : [2 ^^ 128 - 1] -> _) :
  [340282366920938463463374607431768211455] -> [512]
Primitive::Keyless::Hash::SHA2::Instantiations::SHA512> :t hash : [2^^128] -> _

[error] at <interactive>:2:4--2:24:
  • Unsolvable constraint:
      MessageUpperBound >= 129
        arising from
        use of expression hash
        at <interactive>:2:4--2:8
```