### PR TITLE
SHA3: Attempt at Bugfix

### DIFF
--- a/Primitive/Keyless/Hash/SHA3/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA3/Specification.cry
@@ -282,7 +282,7 @@ private
      *
      * [FIPS-202] Section 3.2.5, Algorithm 5.
      */
-    rc : Integer -> Bit
+    rc : [8] -> Bit
     rc t = if (t % 255) == 0 then 1 // Step 1.
          else Rs @ (t % 255) @0 // Step 4.
          where
@@ -313,7 +313,7 @@ private
      *
      * Equivalent to [FIPS-202] Section 3.2.5, Algorithm 5.
      */
-    rc_hardcoded : Integer -> Bit
+    rc_hardcoded : [8] -> Bit
     rc_hardcoded t = constants @ (t % 255) where
         constants = join [
             0x80b1e87f90a7d57062b32fde6ee54a25,
@@ -344,7 +344,12 @@ private
         // Step 3. 0 is the identity for XOR, so we iteratively set the
         // `2^j-1`th element by XORing the previously-set bits of RC with the
         // correct value at the desired index.
-        RCs = [RC0] # [RC' ^ (zext`{w} [rc_hardcoded (toInteger j + 7 * ir)] << (2^^j - 1))
+        // `mod` is a homomorphism between `Integer` and `[8]`.
+        // This means that `mod` "commutes" with addition and multiplication of `Integer`.
+        // Because of this, it is safe, from the perspective of correctness,
+        // to consider `ir` as a `[8]`.
+        ir' = fromInteger ir :[8]
+        RCs = [RC0] # [RC' ^ (zext`{w} [rc_hardcoded (j + 7 * ir')] << (2^^j - 1))
             | RC' <- RCs
             | j <- [0..ell] ]
         RC = (RCs ! 0) : [w]

--- a/Primitive/Keyless/Hash/SHA3/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA3/Specification.cry
@@ -282,7 +282,7 @@ private
      *
      * [FIPS-202] Section 3.2.5, Algorithm 5.
      */
-    rc : [8] -> Bit
+    rc : Integer -> Bit
     rc t = if (t % 255) == 0 then 1 // Step 1.
          else Rs @ (t % 255) @0 // Step 4.
          where
@@ -313,7 +313,7 @@ private
      *
      * Equivalent to [FIPS-202] Section 3.2.5, Algorithm 5.
      */
-    rc_hardcoded : [8] -> Bit
+    rc_hardcoded : Integer -> Bit
     rc_hardcoded t = constants @ (t % 255) where
         constants = join [
             0x80b1e87f90a7d57062b32fde6ee54a25,
@@ -344,12 +344,7 @@ private
         // Step 3. 0 is the identity for XOR, so we iteratively set the
         // `2^j-1`th element by XORing the previously-set bits of RC with the
         // correct value at the desired index.
-        // `mod` is a homomorphism between `Integer` and `[8]`.
-        // This means that `mod` "commutes" with addition and multiplication of `Integer`.
-        // Because of this, it is safe, from the perspective of correctness,
-        // to consider `ir` as a `[8]`.
-        ir' = fromInteger ir :[8]
-        RCs = [RC0] # [RC' ^ (zext`{w} [rc_hardcoded (j + 7 * ir')] << (2^^j - 1))
+        RCs = [RC0] # [RC' ^ (zext`{w} [rc_hardcoded (toInteger j + 7 * ir)] << (2^^j - 1))
             | RC' <- RCs
             | j <- [0..ell] ]
         RC = (RCs ! 0) : [w]

--- a/Primitive/Keyless/Hash/SHA3/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA3/Specification.cry
@@ -284,10 +284,9 @@ private
      */
     rc : Integer -> Bit
     rc t = if (t % 255) == 0 then 1 // Step 1.
-         else Rs @ (t'') @0 // Step 4.
+         else Rs @ (t') @0 // Step 4.
          where
-             t' = t % 255
-             t'' = fromInteger t' : [8]
+             t' = fromInteger (t % 255) : [8]
              // Step 2 - 3.
              Rs = [0b10000000] # [lfsr R | R <- Rs ]
              // Step 3. Linear feedback shift register.
@@ -316,13 +315,12 @@ private
      * Equivalent to [FIPS-202] Section 3.2.5, Algorithm 5.
      */
     rc_hardcoded : Integer -> Bit
-    rc_hardcoded t = constants @ (t'') where
+    rc_hardcoded t = constants @ (t') where
         constants = join [
             0x80b1e87f90a7d57062b32fde6ee54a25,
             0xa339e361175edf0d35b504ec9303a471
         ]
-        t' = t % 255
-        t'' = fromInteger t' : [8]
+        t' = fromInteger (t % 255) : [8]
 
     /**
      * Prove that the hardcoded round constants are correct.

--- a/Primitive/Keyless/Hash/SHA3/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA3/Specification.cry
@@ -284,8 +284,10 @@ private
      */
     rc : Integer -> Bit
     rc t = if (t % 255) == 0 then 1 // Step 1.
-         else Rs @ (t % 255) @0 // Step 4.
+         else Rs @ (t'') @0 // Step 4.
          where
+             t' = t % 255
+             t'' = fromInteger t' : [8]
              // Step 2 - 3.
              Rs = [0b10000000] # [lfsr R | R <- Rs ]
              // Step 3. Linear feedback shift register.
@@ -314,11 +316,13 @@ private
      * Equivalent to [FIPS-202] Section 3.2.5, Algorithm 5.
      */
     rc_hardcoded : Integer -> Bit
-    rc_hardcoded t = constants @ (t % 255) where
+    rc_hardcoded t = constants @ (t'') where
         constants = join [
             0x80b1e87f90a7d57062b32fde6ee54a25,
             0xa339e361175edf0d35b504ec9303a471
         ]
+        t' = t % 255
+        t'' = fromInteger t' : [8]
 
     /**
      * Prove that the hardcoded round constants are correct.

--- a/Primitive/Keyless/Hash/SHA3/Specification.cry
+++ b/Primitive/Keyless/Hash/SHA3/Specification.cry
@@ -286,7 +286,6 @@ private
     rc t = if (t % 255) == 0 then 1 // Step 1.
          else Rs @ (t') @0 // Step 4.
          where
-             t' = fromInteger (t % 255) : [8]
              // Step 2 - 3.
              Rs = [0b10000000] # [lfsr R | R <- Rs ]
              // Step 3. Linear feedback shift register.
@@ -299,6 +298,11 @@ private
                      R4 = R@4 ^ R@8
                      R5 = R@5 ^ R@8
                      R6 = R@6 ^ R@8
+             // Cryptol's SMT interface disallows index by symbolic `Integer`.
+             // To faciliate proofs, we convert to a bitvector.
+             // Justification: for all integers i,
+             // (i % 255) % 256 == (i % 255)
+             t' = fromInteger (t % 255) : [8]
 
     /**
      * Hardcode the round constant values.
@@ -320,7 +324,43 @@ private
             0x80b1e87f90a7d57062b32fde6ee54a25,
             0xa339e361175edf0d35b504ec9303a471
         ]
+        // Cryptol's SMT interface disallows index by symbolic `Integer`.
+        // To faciliate proofs, we convert to a bitvector.
+        // Justification: for all integers i,
+        // (i % 255) % 256 == (i % 255)
         t' = fromInteger (t % 255) : [8]
+
+    /*
+     * Some properties justifying the conversion of `Integer -> [8]`
+     * in `rc` and `rc_hardcoded`
+     */
+    private
+        /**
+        * A fact about modular arithmetic:
+        *   For any integers `i`, `m`, `n`, such that `m > 0` and `m < n`,
+        *   `i mod m mod n == i mod m`
+        *   I.e., the modular reduction is equivalent to the smaller modulus.
+        */
+        index_eq: {ix} (Integral ix, Cmp ix, Literal 0 ix) => ix -> ix -> ix -> Bit
+        index_eq i m n = m > 0 ==> m <= n ==> (i % m) % n == (i % m)
+
+        /**
+        * An instance of the fact above for Cryptol `Integer`.
+        * ```repl
+        * :prove index_eq_int
+        * ```
+        */
+        property index_eq_int = index_eq `{Integer}
+
+        /**
+        * A consequence of the property above is that reducing an integer
+        * mod 255 and then converting it to an `[8]` is always in `Z 255`.
+        * ```repl
+        * :prove value_bound
+        * ```
+        */
+        value_bound: Integer -> Bit
+        property value_bound i = (fromInteger (i % 255) : [8]) < 255
 
     /**
      * Prove that the hardcoded round constants are correct.


### PR DESCRIPTION
Appeal to `mod` as a homomorphism from `Integer` to Z 256 ~~ `[8]`, since `ir` is computed with addition and multiplication..