### PR TITLE
Refactor `AESKeyWrap` and `AESKeyWrapPadded` to use `Option`

### DIFF
--- a/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrap.cry
+++ b/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrap.cry
@@ -58,10 +58,10 @@ aesWrapKey key iv plaintext = split (join C)
 // plain text.  If the integrity check fails, the second element will be all
 // zeros.
 aesUnwrapKey : {n} (fin n, n >= 24, n % 8 == 0, width (n / 8) <= 64) =>
-               [AESKeySize] -> [8][8] -> [n][8] -> (Bit, [n-8][8])
+               [AESKeySize] -> [8][8] -> [n][8] -> Option ([n-8][8])
 aesUnwrapKey key iv ciphertext = if (join iv) == A'
-                                 then (True, split (join R'))
-                                 else (False, zero)
+                                 then Some (split (join R'))
+                                 else None
   where
     (A', R') = aesUnwrapKeyUnchecked key ciphertext
 

--- a/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrapPadded.cry
+++ b/Primitive/Symmetric/Cipher/Block/Modes/AESKeyWrapPadded.cry
@@ -67,10 +67,10 @@ aesWrapKeyPadded key iv plaintext =
 // the function must remove this padding themselves.  If the integrity check
 // fails, the second and third elements will be zeros.
 aesUnwrapKeyPadded : {n} (fin n, n >= 16, n % 8 == 0, width n <= 32) =>
-                     [AESKeySize] -> [4][8] -> [n][8] -> (Bit, [4][8], [n-8][8])
+                     [AESKeySize] -> [4][8] -> [n][8] -> Option ([4][8], [n-8][8])
 aesUnwrapKeyPadded key iv ciphertext = if valid
-                                       then (True, size, P)
-                                       else (False, zero, zero)
+                                       then Some (size, P)
+                                       else None
   where
     S : [n][8]
     S = if `n == 16

--- a/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrap.cry
+++ b/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrap.cry
@@ -1,5 +1,6 @@
 module Primitive::Symmetric::Cipher::Block::Tests::TestAESKeyWrap where
 
+import Common::OptionUtils
 import Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrap
 
 // This section contains tests of the Key Wrap specifications using test
@@ -17,9 +18,18 @@ KeyData128 = split 0x00112233445566778899AABBCCDDEEFF
 Ciphertext128_256 : [24][8]
 Ciphertext128_256 = split 0x64E8C3F9CE0F5BA263E9777905818A2A93C8191E7D6E8AE7
 
-// Test wrapping and unwrapping of KeyData128 with KEK256 (Section 4.3)
+/**
+ * Test wrapping and unwrapping of KeyData128 with KEK256 (Section 4.3)
+ *
+ * ```repl
+ * :prove testWrap128_256
+ * :prove testUnwrap128_256
+ * ```
+ */
 property testWrap128_256 = (aesWrapKey KEK256 DefaultIV KeyData128) == Ciphertext128_256
-property testUnwrap128_256 = (aesUnwrapKey KEK256 DefaultIV Ciphertext128_256) == (True, KeyData128)
+property testUnwrap128_256 = optFold False (\a -> KeyData128 == a) result
+    where
+        result = aesUnwrapKey KEK256 DefaultIV Ciphertext128_256
 
 // 192-bit key data to encrypt
 KeyData192 : [24][8]
@@ -29,9 +39,18 @@ KeyData192 = split 0x00112233445566778899AABBCCDDEEFF0001020304050607
 Ciphertext192_256 : [32][8]
 Ciphertext192_256 = split 0xA8F9BC1612C68B3FF6E6F4FBE30E71E4769C8B80A32CB8958CD5D17D6B254DA1
 
-// Test wrapping and unwrapping of KeyData192 with KEK256 (Section 4.5)
+/**
+ * Test wrapping and unwrapping of KeyData192 with KEK256 (Section 4.5)
+ *
+ * ```repl
+ * :prove testWrap192_256
+ * :prove testUnwrap192_256
+ * ```
+ */
 property testWrap192_256 = (aesWrapKey KEK256 DefaultIV KeyData192) == Ciphertext192_256
-property testUnwrap192_256 = (aesUnwrapKey KEK256 DefaultIV Ciphertext192_256) == (True, KeyData192)
+property testUnwrap192_256 = optFold False (\a -> KeyData192 == a) result
+    where
+        result = aesUnwrapKey KEK256 DefaultIV Ciphertext192_256
 
 // 256-bit key data to encrypt
 KeyData256 : [32][8]
@@ -41,13 +60,34 @@ KeyData256 = split 0x00112233445566778899AABBCCDDEEFF000102030405060708090A0B0C0
 Ciphertext256_256 : [40][8]
 Ciphertext256_256 = split 0x28C9F404C4B810F4CBCCB35CFB87F8263F5786E2D80ED326CBC7F0E71A99F43BFB988B9B7A02DD21
 
-// Test wrapping and unwrapping of KeyData256 with KEK256 (Section 4.6)
+/**
+ * Test wrapping and unwrapping of KeyData256 with KEK256 (Section 4.6)
+ *
+ * ```repl
+ * :prove testWrap256_256
+ * :prove testUnwrap256_256
+ * ```
+ */
 property testWrap256_256 = (aesWrapKey KEK256 DefaultIV KeyData256) == Ciphertext256_256
-property testUnwrap256_256 = (aesUnwrapKey KEK256 DefaultIV Ciphertext256_256) == (True, KeyData256)
+property testUnwrap256_256 = optFold False (\a -> KeyData256 == a) result
+    where
+        result = aesUnwrapKey KEK256 DefaultIV Ciphertext256_256
 
-/*
+/**
  * The following tests come from the NIST Key Wrap Validation System (KWVS)
  * KW-AD-AES256 test vectors.
+ *
+ * ```repl
+ * :prove Count0Wrap
+ * :prove Count0Unwrap
+ * :prove Count1Wrap
+ * :prove Count1Unwrap
+ * :prove Count2Wrap
+ * :prove Count2Unwrap
+ * :prove Count3Wrap
+ * :prove Count3Unwrap
+ * :prove Count4Unwrap
+ * ```
  */
 
 //COUNT = 0
@@ -55,30 +95,38 @@ KCount0 = 0x80aa997327a4806b6a7a41a52b86c3710386f932786ef79676fafb90b8263c5f
 PCount0 = split`{each=8} 0x0a256ba75cfa03aaa02ba94203f15baa
 CCount0 = split`{each=8} 0x423c960d8a2ac4c1d33d3d977bf0a91559f99c8acd293d43
 property Count0Wrap = (aesWrapKey KCount0 DefaultIV PCount0) == CCount0
-property Count0Unwrap = (aesUnwrapKey KCount0 DefaultIV CCount0) == (True, PCount0)
+property Count0Unwrap = optFold False (\a -> PCount0 == a) result
+    where
+        result = aesUnwrapKey KCount0 DefaultIV CCount0
 
 //COUNT = 1
 KCount1 = 0x2d104bc65c5f78e92993bd78b27d8e59a8a1f7c64b55b05be5df30f96ff04767
 CCount1 = split`{each=8} 0xe69fc01ea73e11bb4bc7485044145f824cfd535528b76517
 PCount1 = split`{each=8} 0xf8d46471445228d2ef399755360bdd6e
 property Count1Wrap = (aesWrapKey KCount1 DefaultIV PCount1) == CCount1
-property Count1Unwrap = (aesUnwrapKey KCount1 DefaultIV CCount1) == (True, PCount1)
+property Count1Unwrap = optFold False (\a -> PCount1 == a) result
+    where
+        result = aesUnwrapKey KCount1 DefaultIV CCount1
 
 //COUNT = 2
 KCount2 = 0xd963c8f1d3d2392629823fd1df3f644c8690f602c94e5d5818309d7c05e5427f
 CCount2 = split`{each=8} 0x177c6217f7fd6c94cbd4a9f512b1416c869328e3084e09ea
 PCount2 = split`{each=8} 0x451d0222ec29755d9c69165a5d109727
 property Count2Wrap = (aesWrapKey KCount2 DefaultIV PCount2) == CCount2
-property Count2Unwrap = (aesUnwrapKey KCount2 DefaultIV CCount2) == (True, PCount2)
+property Count2Unwrap = optFold False (\a -> PCount2 == a) result
+    where
+        result = aesUnwrapKey KCount2 DefaultIV CCount2
 
 //COUNT = 3
 KCount3 = 0xe594f0067cedb74e883e7746d29ba725c884c25375323f367cf49d17ad0f567b
 CCount3 = split`{each=8} 0x3b51ae2b0e3ddeed94efd7bfdc22630187e1f7624d15ed78
 PCount3 = split`{each=8} 0x587e3f6c75644bb5c3db9c74714f5556
 property Count3Wrap = (aesWrapKey KCount3 DefaultIV PCount3) == CCount3
-property Count3Unwrap = (aesUnwrapKey KCount3 DefaultIV CCount3) == (True, PCount3)
+property Count3Unwrap = optFold False (\a -> PCount3 == a) result
+    where
+        result = aesUnwrapKey KCount3 DefaultIV CCount3
 
 //COUNT = 4 (validation failure)
 KCount4 = 0x08c936b25b567a0aa679c29f201bf8b190327df0c2563e39cee061f149f4d91b
 CCount4 = split`{each=8} 0xe227eb8ae9d239ccd8928adec39c28810ca9b3dc1f366444
-property Count4Unwrap = (aesUnwrapKey KCount4 DefaultIV CCount4) == (False, zero)
+property Count4Unwrap = isNone (aesUnwrapKey KCount4 DefaultIV CCount4)

--- a/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrapPadded.cry
+++ b/Primitive/Symmetric/Cipher/Block/Tests/TestAESKeyWrapPadded.cry
@@ -1,5 +1,6 @@
 module Primitive::Symmetric::Cipher::Block::Tests::TestAESKeyWrapPadded where
 
+import Common::OptionUtils
 import Primitive::Symmetric::Cipher::Block::Instantiations::AES256_KeyWrapPadded
 
 testUnwrap : {a, b} ( fin a
@@ -9,12 +10,26 @@ testUnwrap : {a, b} ( fin a
                     , a >= 16
                     , a % 8 == 0) =>
              [AESKeySize] -> [a][8] -> [b][8] -> Bit
-testUnwrap key ct pt = (invalid, join size, take`{b} pt') == (True, `b, pt)
-  where (invalid, size, pt') = aesUnwrapKeyPadded key AlternativeIV ct
+testUnwrap key ct pt = optFold False (\a -> (join a.0, take`{b} a.1) == (`b, pt)) result
+  where 
+    result = aesUnwrapKeyPadded key AlternativeIV ct
 
-/*
+/**
  * The following tests come from the NIST Key Wrap Validation System (KWVS)
- * KWP-AE-AES256 test vectors
+ * KWP-AE-AES256 test vectors.
+ *
+ * ```repl
+ * :prove TV_00KWrap
+ * :prove TV_00KUnwrap
+ * :prove TV_01KWrap
+ * :prove TV_01KUnwrap
+ * :prove TV_02KWrap
+ * :prove TV_02KUnwrap
+ * :prove TV_03KWrap
+ * :prove TV_03KUnwrap
+ * :prove TV_04KWrap
+ * :prove TV_04KUnwrap
+ * ```
  */
 
 TV_00K = 0x95da2700ca6fd9a52554ee2a8df1386f5b94a1a60ed8a4aef60a8d61ab5f225a
@@ -50,7 +65,25 @@ property TV_04KUnwrap = testUnwrap TV_04K TV_04C TV_04P
 
 /*
  * The following tests come from the NIST Key Wrap Validation System (KWVS)
- * KWP-AD-AES256 test vectors
+ * KWP-AD-AES256 test vectors.
+ *
+ * ```repl
+ * :prove TV_INV_00KWrap
+ * :prove TV_INV_00KUnwrap
+ * :prove TV_INV_00KUnwrap'
+ * :prove TV_INV_01KWrap
+ * :prove TV_INV_01KUnwrap
+ * :prove TV_INV_01KUnwrap'
+ * :prove TV_INV_02KWrap
+ * :prove TV_INV_02KUnwrap
+ * :prove TV_INV_02KUnwrap'
+ * :prove TV_INV_03KWrap
+ * :prove TV_INV_03KUnwrap
+ * :prove TV_INV_03KUnwrap'
+ * :prove TV_INV_04KWrap
+ * :prove TV_INV_04KUnwrap
+ * :prove TV_INV_04KUnwrap'
+ * ```
  */
 
 // PLAINTEXT LENGTH = 8, COUNT = 0
@@ -62,7 +95,7 @@ property TV_INV_00KUnwrap = testUnwrap TV_INV_00K TV_INV_00C TV_INV_00P
 
 TV_INV_00K' = 0x20e4ff6a88ffa9a2818b81702793d8a016722c2fa1ff445f24b9db293cb12069
 TV_INV_00C' = split`{each=8} 0xdeadbeef27b167f411b0b8e21b11d819
-property TV_INV_00KUnwrap' = (aesUnwrapKeyPadded TV_INV_00K' AlternativeIV TV_INV_00C') == (False, zero, zero)
+property TV_INV_00KUnwrap' = isNone (aesUnwrapKeyPadded TV_INV_00K' AlternativeIV TV_INV_00C')
 
 TV_INV_01K = 0x96503e950d01ee1664de77ef6c0108aea2cffcffd0cf282e58a3fb982914ff9c
 TV_INV_01C = split`{each=8} 0xe5fa8bf0919d5a7163f2af43b3b549b8
@@ -72,7 +105,7 @@ property TV_INV_01KUnwrap = testUnwrap TV_INV_01K TV_INV_01C TV_INV_01P
 
 TV_INV_01K' = 0x96503e950d01ee1664de77ef6c0108aea2cffcffd0cf282e58a3fb982914ff9c
 TV_INV_01C' = split`{each=8} 0xdeadbeef919d5a7163f2af43b3b549b8
-property TV_INV_01KUnwrap' = (aesUnwrapKeyPadded TV_INV_01K' AlternativeIV TV_INV_01C') == (False, zero, zero)
+property TV_INV_01KUnwrap' = isNone (aesUnwrapKeyPadded TV_INV_01K' AlternativeIV TV_INV_01C')
 
 TV_INV_02K = 0x0e6d542f960c7e61ca190d7fd719fda157030a0a013164613a8c522b52ae685d
 TV_INV_02C = split`{each=8} 0xb5cae8a82095abb3478ab167dbc0201d2f4dfc5f81bbe44e
@@ -82,7 +115,7 @@ property TV_INV_02KUnwrap = testUnwrap TV_INV_02K TV_INV_02C TV_INV_02P
 
 TV_INV_02K' = 0x0e6d542f960c7e61ca190d7fd719fda157030a0a013164613a8c522b52ae685d
 TV_INV_02C' = split`{each=8} 0xdeadbeef2095abb3478ab167dbc0201d2f4dfc5f81bbe44e
-property TV_INV_02KUnwrap' = (aesUnwrapKeyPadded TV_INV_02K' AlternativeIV TV_INV_02C') == (False, zero, zero)
+property TV_INV_02KUnwrap' = isNone (aesUnwrapKeyPadded TV_INV_02K' AlternativeIV TV_INV_02C')
 
 TV_INV_03K = 0x09ab4286a845c18bb481da91c39a58fd52ed78d54973fc41f25163a0c33f4727
 TV_INV_03C = split`{each=8} 0x0a180a84b01fc1e44b9f9301cc89af95de758219015abc86c3e48e764e7379246ae7209aaa4f889d
@@ -92,7 +125,7 @@ property TV_INV_03KUnwrap = testUnwrap TV_INV_03K TV_INV_03C TV_INV_03P
 
 TV_INV_03K' = 0x09ab4286a845c18bb481da91c39a58fd52ed78d54973fc41f25163a0c33f4727
 TV_INV_03C' = split`{each=8} 0xdeadbeefb01fc1e44b9f9301cc89af95de758219015abc86c3e48e764e7379246ae7209aaa4f889d
-property TV_INV_03KUnwrap' = (aesUnwrapKeyPadded TV_INV_03K' AlternativeIV TV_INV_03C') == (False, zero, zero)
+property TV_INV_03KUnwrap' = isNone (aesUnwrapKeyPadded TV_INV_03K' AlternativeIV TV_INV_03C')
 
 TV_INV_04K = 0x08f5c088acec18e6cf1f03a8f85d772e327e7fb07f8c2939eb554e84c42ab93d
 TV_INV_04C = split`{each=8} 0xdff30fd43647d4be54cf2dfd6187e2ddffb55267313f980fb09c833a9c2bfa558a95861711f0acb2a5c7e731ba22f24a9c4dfdd9e9b0216e9088f817a175b9835b0e17615687a20f68c067205626494cd04fbabc0b3eea7c0a4cd6236bc8b3e52e721dfc357fb8a3722bfcc4c690d8f63dbb864bb6e3a15805aea7270f8eb748deebaa2d066fcda11c2e67221f9a91d2c29a6c79ffae76aa80a2590b4f9e35f623fbf2f8ceb2a205493077556a186e25e5bd52dcff7bcc6909b37a66c1d1431be1b363bb40da25386eaaf5fcabc7be6422a04434a21d1d3105328e7c56770b9f59b03395e4138f5f06fc7e6b80dab87b08caa7bfffc45a095c15263efd3f06c651ded6f58074efc20620d704997fc84721a0a8e9e5b9f5cd330bbb156b31d9d1b1c260e4a24535f30404dc5b2dd6b35d916a1391b25a7d8790be09d85483ed1522074a2785812005bda10dd55acb245b3bd3d9bb777dd23f9b02538ba1a114ba53386d7ca4d9524b2f8a18e0ffb21580b560540bb2146f08f04974b90eb324547d56222df95f44bc6e5f183bef283e4816fb1b2933f9c7c6726a245a495e304d8318d0008c51b0be8090f8f668fbc3f31e073be4b9e97468f4dd8c798e9d682868df493db8a85738b58cfd005190f365849072577772672c6f82555c65046eb34e86fe61103327a063bacbbe33cea7eaa3d1de45471b7269e1b6b38608626e323447a3d5fe0599a6
@@ -102,4 +135,4 @@ property TV_INV_04KUnwrap = testUnwrap TV_INV_04K TV_INV_04C TV_INV_04P
 
 TV_INV_04K' = 0x08f5c088acec18e6cf1f03a8f85d772e327e7fb07f8c2939eb554e84c42ab93d
 TV_INV_04C' = split`{each=8} 0xdeadbeef3647d4be54cf2dfd6187e2ddffb55267313f980fb09c833a9c2bfa558a95861711f0acb2a5c7e731ba22f24a9c4dfdd9e9b0216e9088f817a175b9835b0e17615687a20f68c067205626494cd04fbabc0b3eea7c0a4cd6236bc8b3e52e721dfc357fb8a3722bfcc4c690d8f63dbb864bb6e3a15805aea7270f8eb748deebaa2d066fcda11c2e67221f9a91d2c29a6c79ffae76aa80a2590b4f9e35f623fbf2f8ceb2a205493077556a186e25e5bd52dcff7bcc6909b37a66c1d1431be1b363bb40da25386eaaf5fcabc7be6422a04434a21d1d3105328e7c56770b9f59b03395e4138f5f06fc7e6b80dab87b08caa7bfffc45a095c15263efd3f06c651ded6f58074efc20620d704997fc84721a0a8e9e5b9f5cd330bbb156b31d9d1b1c260e4a24535f30404dc5b2dd6b35d916a1391b25a7d8790be09d85483ed1522074a2785812005bda10dd55acb245b3bd3d9bb777dd23f9b02538ba1a114ba53386d7ca4d9524b2f8a18e0ffb21580b560540bb2146f08f04974b90eb324547d56222df95f44bc6e5f183bef283e4816fb1b2933f9c7c6726a245a495e304d8318d0008c51b0be8090f8f668fbc3f31e073be4b9e97468f4dd8c798e9d682868df493db8a85738b58cfd005190f365849072577772672c6f82555c65046eb34e86fe61103327a063bacbbe33cea7eaa3d1de45471b7269e1b6b38608626e323447a3d5fe0599a6
-property TV_INV_04KUnwrap' = (aesUnwrapKeyPadded TV_INV_04K' AlternativeIV TV_INV_04C') == (False, zero, zero)
+property TV_INV_04KUnwrap' = isNone (aesUnwrapKeyPadded TV_INV_04K' AlternativeIV TV_INV_04C')


### PR DESCRIPTION
This partially addresses Issue https://github.com/GaloisInc/cryptol-specs/issues/239 of removing the `(a, Bit)` anti-pattern from the `AESKeyWrap[Padded]` API.