### PR TITLE
Add verification scripts for aesIsCorrect

### DIFF
--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES128.saw
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES128.saw
@@ -1,0 +1,35 @@
+/**
+ * Cryptol AES property verification.
+ *
+ * This module efficiently checks that decrypt is the inverse of encrypt.
+ *
+ * @copyright Galois Inc.
+ * @author Eric Mertens <emertens@galois.com>
+ */
+
+import "../Instantiations/AES128.cry";
+import "../../../../../../Common/GF28.cry" as GF28;
+
+let ss0 = cryptol_ss ();
+
+print "Verifying that cipher unrolls";
+/* This works around SAW having limited reasoning capabilities about sequenes in the simplifier */
+unroll_cipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "MixColumns", "SubBytes", "ShiftRows"])
+    {{ \w pt -> cipher w pt ==
+    (stateToMsg (AddRoundKey (w@10) (ShiftRows (SubBytes (t 9 (t 8 (t 7 (t 6 (t 5 (t 4 (t 3 (t 2 (t 1 (AddRoundKey (w@0) (msgToState pt))))))))))))))
+        where
+        t i state = AddRoundKey (w@i) (MixColumns (ShiftRows (SubBytes state))))
+    }};
+
+print "Verifying that invCipher unrolls";
+/* This works around SAW having limited reasoning capabilities about sequenes in the simplifier */
+unroll_invCipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "InvMixColumns", "InvSubBytes", "InvShiftRows"])
+    {{ \w ct -> invCipher w ct ==
+    (stateToMsg (AddRoundKey (w@0) (InvSubBytes (InvShiftRows (t 1 (t 2 (t 3 (t 4 (t 5 (t 6 (t 7 (t 8 (t 9 (AddRoundKey (w@10) ( msgToState ct))))))))))))))
+        where
+        t i state = InvMixColumns (AddRoundKey (w@i) (InvSubBytes (InvShiftRows state))))
+    }};
+
+include "Common.saw";

--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES192.saw
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES192.saw
@@ -1,0 +1,33 @@
+/**
+ * Cryptol AES property verification.
+ *
+ * This module efficiently checks that decrypt is the inverse of encrypt.
+ *
+ * @copyright Galois Inc.
+ * @author Eric Mertens <emertens@galois.com>
+ */
+
+import "../Instantiations/AES192.cry";
+import "../../../../../../Common/GF28.cry" as GF28;
+
+let ss0 = cryptol_ss ();
+
+print "Verifying that cipher unrolls";
+unroll_cipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "MixColumns", "SubBytes", "ShiftRows"])
+    {{ \w pt -> cipher w pt ==
+    (stateToMsg (AddRoundKey (w@12) (ShiftRows (SubBytes (t 11 (t 10 (t 9 (t 8 (t 7 (t 6 (t 5 (t 4 (t 3 (t 2 (t 1 (AddRoundKey (w@0) (msgToState pt))))))))))))))))
+        where
+        t i state = AddRoundKey (w@i) (MixColumns (ShiftRows (SubBytes state))))
+    }};
+
+print "Verifying that invCipher unrolls";
+unroll_invCipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "InvMixColumns", "InvSubBytes", "InvShiftRows"])
+    {{ \w ct -> invCipher w ct ==
+    (stateToMsg (AddRoundKey (w@0) (InvSubBytes (InvShiftRows (t 1 (t 2 (t 3 (t 4 (t 5 (t 6 (t 7 (t 8 (t 9 (t 10 (t 11 (AddRoundKey (w@12) ( msgToState ct))))))))))))))))
+        where
+        t i state = InvMixColumns (AddRoundKey (w@i) (InvSubBytes (InvShiftRows state))))
+    }};
+
+include "Common.saw";

--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES256.saw
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/AES256.saw
@@ -1,0 +1,33 @@
+/**
+ * Cryptol AES property verification.
+ *
+ * This module efficiently checks that decrypt is the inverse of encrypt.
+ *
+ * @copyright Galois Inc.
+ * @author Eric Mertens <emertens@galois.com>
+ */
+
+import "../Instantiations/AES256.cry";
+import "../../../../../../Common/GF28.cry" as GF28;
+
+let ss0 = cryptol_ss ();
+
+print "Verifying that cipher unrolls";
+unroll_cipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "MixColumns", "SubBytes", "ShiftRows"])
+    {{ \w pt -> cipher w pt ==
+    (stateToMsg (AddRoundKey (w@14) (ShiftRows (SubBytes (t 13 (t 12 (t 11 (t 10 (t 9 (t 8 (t 7 (t 6 (t 5 (t 4 (t 3 (t 2 (t 1 (AddRoundKey (w@0) (msgToState pt))))))))))))))))))
+        where
+        t i state = AddRoundKey (w@i) (MixColumns (ShiftRows (SubBytes state))))
+    }};
+
+print "Verifying that invCipher unrolls";
+unroll_invCipher <- prove_print
+    (w4_unint_z3 ["AddRoundKey", "InvMixColumns", "InvSubBytes", "InvShiftRows"])
+    {{ \w ct -> invCipher w ct ==
+    (stateToMsg (AddRoundKey (w@0) (InvSubBytes (InvShiftRows (t 1 (t 2 (t 3 (t 4 (t 5 (t 6 (t 7 (t 8 (t 9 (t 10 (t 11 (t 12 (t 13 (AddRoundKey (w@14) ( msgToState ct))))))))))))))))))
+        where
+        t i state = InvMixColumns (AddRoundKey (w@i) (InvSubBytes (InvShiftRows state))))
+    }};
+
+include "Common.saw";

--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/Common.saw
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/Common.saw
@@ -4,12 +4,12 @@
 
 print "Verifying that SBox unfolds";
 /* This performance trick is necessary because SAW doesn't memoize sboxTable */
-unfold_SBox <- prove_print (unint_z3 ["inverse", "add"])
+unfold_SBox <- prove_print (unint_z3 ["inverse", "add", "rotateR"])
   {{ \i -> (SBox i == GF28::add [b, b >>> 4, b >>> 5, b >>> 6, b >>> 7, 0x63] where b = GF28::inverse i) }};
 
 print "Verifying that InvSBox unfolds";
 /* This performance trick is necessary because SAW doesn't memoize sboxInvTable */
-unfold_SBoxInv <- prove_print (unint_z3 ["inverse", "add"])
+unfold_SBoxInv <- prove_print (unint_z3 ["inverse", "add", "rotateR"])
   {{ \i -> SBoxInv i == GF28::inverse (GF28::add [i >>> 2, i >>> 5, i >>> 7, 0x05]) }};
 
 print "Verifying that SBoxInv inverts SBox";

--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/Common.saw
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/Common.saw
@@ -1,0 +1,66 @@
+/* This is the shared portion of the verification script for each instantiation.
+ * The structure of each proof is the same for each instantiation after the
+ * initial unfolding of the definition of cipher and invCipher. */
+
+print "Verifying that SBox unfolds";
+/* This performance trick is necessary because SAW doesn't memoize sboxTable */
+unfold_SBox <- prove_print (unint_z3 ["inverse", "add"])
+  {{ \i -> (SBox i == GF28::add [b, b >>> 4, b >>> 5, b >>> 6, b >>> 7, 0x63] where b = GF28::inverse i) }};
+
+print "Verifying that InvSBox unfolds";
+/* This performance trick is necessary because SAW doesn't memoize sboxInvTable */
+unfold_SBoxInv <- prove_print (unint_z3 ["inverse", "add"])
+  {{ \i -> SBoxInv i == GF28::inverse (GF28::add [i >>> 2, i >>> 5, i >>> 7, 0x05]) }};
+
+print "Verifying that SBoxInv inverts SBox";
+invert_SBox <- prove_print
+    do {
+        simplify (addsimps [unfold_SBox, unfold_SBoxInv] ss0);
+        rme;
+    }
+    {{ \s -> SBoxInv (SBox s) == s }};
+
+print "Verifying that InvSubBytes inverts SubBytes";
+invert_SubBytes <- prove_print
+    do {
+        unfolding ["InvSubBytes", "SubBytes"];
+        simplify (add_prelude_eqs ["map_map"] (addsimps [invert_SBox] ss0));
+        rme;
+    }
+    {{ \s -> InvSubBytes (SubBytes s) == s }};
+
+print "Verifying that InvShiftRows inverts ShiftRows";
+invert_ShiftRows <- prove_print rme
+    {{ \s -> InvShiftRows (ShiftRows s) == s }};
+
+print "Verifying that InvMixColumns inverts MixColumns";
+invert_MixColumns <- prove_print rme
+    {{ \s -> InvMixColumns (MixColumns s) == s }};
+
+print "Verifying that msgToState inverts stateToMsg";
+invert_stateToMsg <- prove_print rme {{\s -> msgToState (stateToMsg s) == s}};
+
+print "Verifying that stateToMsg inverts msgToState";
+invert_msgToState <- prove_print rme {{\s -> stateToMsg (msgToState s) == s}};
+
+print "Verifying that AddRoundKey is involutive";
+invert_AddRoundKey <- prove_print rme
+    {{ \x y -> AddRoundKey x (AddRoundKey x y) == y }};
+
+print "Verifying that invCipher inverts cipher";
+invert_cipher <- prove_print do {
+    simplify (addsimps
+        [unroll_cipher, unroll_invCipher, invert_ShiftRows,
+         invert_MixColumns, invert_SubBytes, invert_msgToState,
+         invert_stateToMsg, invert_msgToState, invert_AddRoundKey] ss0);
+    rme;
+   }
+   {{ \w pt -> invCipher w (cipher w pt) == pt }};
+
+print "Verifying that decrypt inverts encrypt";
+prove_print do {
+    unfolding ["aesIsCorrect", "encrypt", "decrypt"];
+    simplify (addsimps [invert_cipher] ss0);
+    rme;
+   }
+   {{ aesIsCorrect }};

--- a/Primitive/Symmetric/Cipher/Block/AES/Verifications/README.md
+++ b/Primitive/Symmetric/Cipher/Block/AES/Verifications/README.md
@@ -1,0 +1,27 @@
+Some of the properties in AES cannot be proven natively by Cryptol (or at least, the proofs are slow enough that we haven't waited to see them complete). These properties are currently:
+- `mixColumnsInverts`: this property shows that the `mixColumns` and `InvMixColumns` properties are each others inverse
+- `aesIsCorrect`: this property shows that the AES `encrypt` and `decrypt` functions are each others inverses.
+
+To provide a stronger assurance case, the SAW scripts in this folder prove the `aesIsCorrect` property. A side effect of this proof is a proof that `mixColumnsInverts` is also true.
+
+If you have a [working SAW installation](https://github.com/GaloisInc/saw-script/), version 1.3 or later, you can get assurance of these properties:
+```
+$ cd Primitive/Symmetric/Cipher/Block/AES/Verifications
+$ saw AES128.saw
+
+[16:08:13.949] Loading file "Primitive/Symmetric/Cipher/Block/AES/Verifications/AES128.saw"
+[16:08:14.082] Verifying that cipher unrolls
+[16:08:14.157] Verifying that invCipher unrolls
+[16:08:14.248] Loading file "Primitive/Symmetric/Cipher/Block/AES/Verifications/Common.saw"
+[16:08:14.248] Verifying that SBox unfolds
+[16:08:14.529] Verifying that InvSBox unfolds
+[16:08:14.747] Verifying that SBoxInv inverts SBox
+[16:08:14.980] Verifying that InvSubBytes inverts SubBytes
+[16:08:15.012] Verifying that InvShiftRows inverts ShiftRows
+[16:08:15.028] Verifying that InvMixColumns inverts MixColumns
+[16:08:15.627] Verifying that msgToState inverts stateToMsg
+[16:08:15.643] Verifying that stateToMsg inverts msgToState
+[16:08:15.658] Verifying that AddRoundKey is involutive
+[16:08:15.674] Verifying that invCipher inverts cipher
+[16:08:15.697] Verifying that decrypt inverts encrypt
+```


### PR DESCRIPTION
These scripts are based off examples found in the SAW examples directory. Those examples had bitrotted because this specification had moved on. I think it would be useful for us to keep the script needed to verify the properties close to the spec so they can stay in sync now that it's updated.