### PR TITLE
SHA256 FFI implementation

### DIFF
--- a/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.c
+++ b/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.c
@@ -1,0 +1,188 @@
+#include "SHA256_FFI.h"
+
+/*********************************************************************
+* Filename:   sha256.c
+* Author:     Brad Conte (brad AT bradconte.com)
+* Copyright:
+* Disclaimer: This code is presented "as is" without any guarantees.
+* Details:    Implementation of the SHA-256 hashing algorithm.
+              SHA-256 is one of the three algorithms in the SHA2
+              specification. The others, SHA-384 and SHA-512, are not
+              offered in this implementation.
+              Algorithm specification can be found here:
+               * http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf
+              This implementation uses little endian byte order.
+*********************************************************************/
+
+/*************************** HEADER FILES ***************************/
+#include <stdlib.h>
+#include <memory.h>
+
+/****************************** MACROS ******************************/
+#define SHA256_BLOCK_SIZE 32 // SHA256 outputs a 32 byte digest
+
+/**************************** DATA TYPES ****************************/
+typedef unsigned char BYTE; // 8-bit byte
+typedef unsigned int WORD;  // 32-bit word, change to "long" for 16-bit machines
+
+typedef struct
+{
+    BYTE data[64];
+    WORD datalen;
+    unsigned long long bitlen;
+    WORD state[8];
+} SHA256_CTX;
+
+/****************************** MACROS ******************************/
+#define ROTLEFT(a, b) (((a) << (b)) | ((a) >> (32 - (b))))
+#define ROTRIGHT(a, b) (((a) >> (b)) | ((a) << (32 - (b))))
+
+#define CH(x, y, z) (((x) & (y)) ^ (~(x) & (z)))
+#define MAJ(x, y, z) (((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)))
+#define EP0(x) (ROTRIGHT(x, 2) ^ ROTRIGHT(x, 13) ^ ROTRIGHT(x, 22))
+#define EP1(x) (ROTRIGHT(x, 6) ^ ROTRIGHT(x, 11) ^ ROTRIGHT(x, 25))
+#define SIG0(x) (ROTRIGHT(x, 7) ^ ROTRIGHT(x, 18) ^ ((x) >> 3))
+#define SIG1(x) (ROTRIGHT(x, 17) ^ ROTRIGHT(x, 19) ^ ((x) >> 10))
+
+/**************************** VARIABLES *****************************/
+static const WORD k[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+    0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+    0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+    0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+    0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+    0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+/*********************** FUNCTION DEFINITIONS ***********************/
+void sha256_transform(SHA256_CTX *ctx, const BYTE data[])
+{
+    WORD a, b, c, d, e, f, g, h, i, j, t1, t2, m[64];
+
+    for (i = 0, j = 0; i < 16; ++i, j += 4)
+        m[i] = (data[j] << 24) | (data[j + 1] << 16) | (data[j + 2] << 8) | (data[j + 3]);
+    for (; i < 64; ++i)
+        m[i] = SIG1(m[i - 2]) + m[i - 7] + SIG0(m[i - 15]) + m[i - 16];
+
+    a = ctx->state[0];
+    b = ctx->state[1];
+    c = ctx->state[2];
+    d = ctx->state[3];
+    e = ctx->state[4];
+    f = ctx->state[5];
+    g = ctx->state[6];
+    h = ctx->state[7];
+
+    for (i = 0; i < 64; ++i)
+    {
+        t1 = h + EP1(e) + CH(e, f, g) + k[i] + m[i];
+        t2 = EP0(a) + MAJ(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    ctx->state[0] += a;
+    ctx->state[1] += b;
+    ctx->state[2] += c;
+    ctx->state[3] += d;
+    ctx->state[4] += e;
+    ctx->state[5] += f;
+    ctx->state[6] += g;
+    ctx->state[7] += h;
+}
+
+void sha256_init(SHA256_CTX *ctx)
+{
+    ctx->datalen = 0;
+    ctx->bitlen = 0;
+    ctx->state[0] = 0x6a09e667;
+    ctx->state[1] = 0xbb67ae85;
+    ctx->state[2] = 0x3c6ef372;
+    ctx->state[3] = 0xa54ff53a;
+    ctx->state[4] = 0x510e527f;
+    ctx->state[5] = 0x9b05688c;
+    ctx->state[6] = 0x1f83d9ab;
+    ctx->state[7] = 0x5be0cd19;
+}
+
+void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len)
+{
+    WORD i;
+
+    for (i = 0; i < len; ++i)
+    {
+        ctx->data[ctx->datalen] = data[i];
+        ctx->datalen++;
+        if (ctx->datalen == 64)
+        {
+            sha256_transform(ctx, ctx->data);
+            ctx->bitlen += 512;
+            ctx->datalen = 0;
+        }
+    }
+}
+
+void sha256_final(SHA256_CTX *ctx, BYTE hash[])
+{
+    WORD i;
+
+    i = ctx->datalen;
+
+    // Pad whatever data is left in the buffer.
+    if (ctx->datalen < 56)
+    {
+        ctx->data[i++] = 0x80;
+        while (i < 56)
+            ctx->data[i++] = 0x00;
+    }
+    else
+    {
+        ctx->data[i++] = 0x80;
+        while (i < 64)
+            ctx->data[i++] = 0x00;
+        sha256_transform(ctx, ctx->data);
+        memset(ctx->data, 0, 56);
+    }
+
+    // Append to the padding the total message's length in bits and transform.
+    ctx->bitlen += ctx->datalen * 8;
+    ctx->data[63] = ctx->bitlen;
+    ctx->data[62] = ctx->bitlen >> 8;
+    ctx->data[61] = ctx->bitlen >> 16;
+    ctx->data[60] = ctx->bitlen >> 24;
+    ctx->data[59] = ctx->bitlen >> 32;
+    ctx->data[58] = ctx->bitlen >> 40;
+    ctx->data[57] = ctx->bitlen >> 48;
+    ctx->data[56] = ctx->bitlen >> 56;
+    sha256_transform(ctx, ctx->data);
+
+    // Since this implementation uses little endian byte ordering and SHA uses big endian,
+    // reverse all the bytes when copying the final state to the output hash.
+    for (i = 0; i < 4; ++i)
+    {
+        hash[i] = (ctx->state[0] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 4] = (ctx->state[1] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 8] = (ctx->state[2] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 12] = (ctx->state[3] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 16] = (ctx->state[4] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 20] = (ctx->state[5] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 24] = (ctx->state[6] >> (24 - i * 8)) & 0x000000ff;
+        hash[i + 28] = (ctx->state[7] >> (24 - i * 8)) & 0x000000ff;
+    }
+}
+
+void hashBytes(size_t l, uint8_t *in, uint8_t *out)
+{
+    SHA256_CTX ctx;
+
+    sha256_init(&ctx);
+    sha256_update(&ctx, in, l);
+    sha256_final(&ctx, out);
+}

--- a/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.cry
+++ b/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.cry
@@ -1,0 +1,44 @@
+/**
+ * FFI instantiation of the secure hash algorithm SHA-256 as specified in
+ * [FIPS-180-4], Section 5.3.3.
+ *
+ * The FFI implementation is taken from
+ * https://github.com/B-Con/crypto-algorithms, which is released into the public
+ * domain free of any restrictions.
+ *
+ * To use, you must compile the associated `SHA256_FFI.c` file according to your
+ * operating system:
+ *
+ * • Linux: cc -fPIC -shared SHA256_FFI.c -o SHA256_FFI.so
+ * • macOS: cc -dynamiclib SHA256_FFI.c -o SHA256_FFI.dylib
+ * • Windows: cc -fPIC -shared SHA256_FFI.c -o SHA256_FFI.dll
+ *
+ * In addition, you need to be using Cryptol with FFI enabled.
+ *
+ * @copyright Galois, Inc.
+ * @author Alex J Malozemoff <amaloz@galois.com>
+ *
+ * [FIPS-180-4]: National Institute of Standards and Technology. Secure Hash
+ *     Standard (SHS). (Department of Commerce, Washington, D.C.), Federal
+ *     Information Processing Standards Publication (FIPS) NIST FIPS 180-4.
+ *     August 2015.
+ *     @see https://doi.org/10.6028/NIST.FIPS.180-4
+ */
+module Primitive::Keyless::Hash::SHA2::Instantiations::SHA256_FFI where
+    import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256
+
+    // Cryptol FFI does not support bit respresentation types, and hence
+    // the below `hash` function is not supported in FFI.
+    //
+    // foreign hash : {l} (SHA256::ValidMessageLength l)
+    //     => [l] -> [SHA256::DigestLength]
+
+    /**
+     * Secure hash function, computed over bytes.
+     *
+     * This is not explicitly part of the spec, but many applications represent
+     * their input and output over byte strings (rather than bit strings as used
+     * in the spec itself).
+     */
+    foreign hashBytes : {l} (SHA256::ValidMessageLength (8 * l))
+        => [l][8] -> [SHA256::DigestLength / 8][8]

--- a/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.h
+++ b/Primitive/Keyless/Hash/SHA2/Instantiations/SHA256_FFI.h
@@ -1,0 +1,3 @@
+#include <stddef.h>
+#include <stdint.h>
+void hashBytes(size_t l, uint8_t * in, uint8_t * out);

--- a/Primitive/Keyless/Hash/SHA2/Tests/SHA256_FFI.cry
+++ b/Primitive/Keyless/Hash/SHA2/Tests/SHA256_FFI.cry
@@ -1,0 +1,24 @@
+/**
+ * Test for SHA256 FFI implementation.
+ *
+ * We test the SHA256 FFI implementation by comparing its output to the Cryptol
+ * implementation's output.
+ *
+ * @copyright Galois, Inc
+ * @author Alex J. Malozemoff <amaloz@galois.com>
+ */
+module Primitive::Keyless::Hash::SHA2::Tests::SHA256 where
+import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256_FFI as SHA256_FFI
+import Primitive::Keyless::Hash::SHA2::Instantiations::SHA256 as SHA256
+
+/**
+ * ```repl
+ * :check FFIAndCryptolAreEqual`{l=1000}
+ * ```
+ */
+FFIAndCryptolAreEqual : {l} (SHA256::ValidMessageLength (8 * l))
+    => [l][8] -> Bool
+property FFIAndCryptolAreEqual M = ffi == cryptol where
+    ffi = SHA256_FFI::hashBytes M
+    cryptol = SHA256::hashBytes M
+


### PR DESCRIPTION
This PR adds an FFI implementation of `SHA256::hashBytes`. It uses a public domain implementation of SHA256, and includes a test that validates that the FFI implementation outputs the same values as the Cryptol version.