### PR TITLE
Remove unnecessary CI install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ jobs:
       image: ghcr.io/galoisinc/cryptol:nightly
       options: --user root
     steps:
-    - name: Installing dependencies..
-      run: |
-        apt update
-        apt install -y git
-
     - name: Checkout
       uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #314.

Saves us 10s per run!