### PR TITLE
docs: fix simon/speck lines in cipher table

### DIFF
--- a/Primitive/Symmetric/Cipher/Block/README.md
+++ b/Primitive/Symmetric/Cipher/Block/README.md
@@ -11,8 +11,8 @@ Symmetric ciphers that work on a block at a time.
 | PRESENT | | No |
 | PRINCE | | No |
 | SHACAL | | No |
-| Simon | | Yes |
-| Speck | | Yes |
+| Simon |Yes | No |
+| Speck | Yes | No |
 | TEA | | No |
 | Threefish | | No |
 | TripleDES | | No |


### PR DESCRIPTION
The "gold standard" indication was filled in incorrectly. Fixed here.