### PR TITLE
`Common::mul_java`: Remove redundant import

### DIFF
--- a/Common/mul_java.cry
+++ b/Common/mul_java.cry
@@ -1,3 +1,9 @@
+/*
+ * @copyright Galois, Inc.
+ * @author Nichole Schimanski <nls@galois.com>
+ * @editor Brian Huffman <huffman@galois.com>
+ * @editor Ryan Scott <rscott@galois.com>
+ */
 module Common::mul_java where
 
 mul_java_inner : (Bit, [24][32], [32], [32], [32], [64]) -> { mji_a : [24][32], mji_d : [64]}

--- a/Common/mul_java.cry
+++ b/Common/mul_java.cry
@@ -1,7 +1,5 @@
 module Common::mul_java where
 
-import Common::bv
-
 mul_java_inner : (Bit, [24][32], [32], [32], [32], [64]) -> { mji_a : [24][32], mji_d : [64]}
 mul_java_inner (azero, a, ij, xi, yj, d) = { mji_a = a', mji_d = d' >> 32 }
   where


### PR DESCRIPTION
While editing `mul_java` recently, I noticed that this import is not bringing anything into scope that the module uses. Let's remove the import to simplify the code.