### PR TITLE
Require fin d for Sphincs 3.1

### DIFF
--- a/Primitive/Asymmetric/Signature/SphincsPlus/3.1/specification.tex
+++ b/Primitive/Asymmetric/Signature/SphincsPlus/3.1/specification.tex
@@ -2352,7 +2352,7 @@ generation.
     type h : #
     type constraint (fin h)
     type d : #
-    type constraint (d >= 2, h%d == 0, h/d >= 1)
+    type constraint (fin d, d >= 2, h%d == 0, h/d >= 1)
     // the following constraint is needed because
     // h - h/d bits should define a tree address
     type constraint (3*4*8 >= h - h/d)


### PR DESCRIPTION
This was already implicitly required due to the constraint (h/d >= 1)

This being explicit fixes some ambiguous type errors generated by uses of drop in the file.