### PR TITLE
`ECDSA`: don't mark `checkSignature` as a property

### DIFF
--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P224_SHA224.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P224_SHA224.cry
@@ -14,7 +14,7 @@ module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P224_SHA224 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P224_SHA224 as ECDSA
 import Common::utils(BVtoZ)
 
-property checkSignature d msg k expected_r expected_s =
+checkSignature d msg k expected_r expected_s =
     signIsCorrect && verifyIsCorrect where
 
     sig = ECDSA::sign msg d k

--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P224_SHA224.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P224_SHA224.cry
@@ -8,6 +8,7 @@
  *
  * @copyright Galois, Inc.
  * @author Marcella Hastings <marcella@galois.com>
+ * @editor Ryan Scott <rscott@galois.com>
  */
 module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P224_SHA224 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P224_SHA224 as ECDSA

--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry
@@ -8,6 +8,7 @@
  *
  * @copyright Galois, Inc.
  * @author Marcella Hastings <marcella@galois.com>
+ * @editor Ryan Scott <rscott@galois.com>
  */
 module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P256_SHA256 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P256_SHA256 as ECDSA

--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry
@@ -14,7 +14,7 @@ module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P256_SHA256 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P256_SHA256 as ECDSA
 import Common::utils(BVtoZ)
 
-property checkSignature d msg k expected_r expected_s =
+checkSignature d msg k expected_r expected_s =
     signIsCorrect && verifyIsCorrect where
 
     sig = ECDSA::sign msg d k

--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry
@@ -14,7 +14,7 @@ module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P384_SHA384 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P384_SHA384 as ECDSA
 import Common::utils(BVtoZ)
 
-property checkSignature d msg k expected_r expected_s =
+checkSignature d msg k expected_r expected_s =
     signIsCorrect && verifyIsCorrect where
 
     sig = ECDSA::sign msg d k

--- a/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry
+++ b/Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry
@@ -8,6 +8,7 @@
  *
  * @copyright Galois, Inc.
  * @author Marcella Hastings <marcella@galois.com>
+ * @editor Ryan Scott <rscott@galois.com>
  */
 module Primitive::Asymmetric::Signature::ECDSA::Tests::ECDSA_P384_SHA384 where
 import Primitive::Asymmetric::Signature::ECDSA::Instantiations::ECDSA_P384_SHA384 as ECDSA


### PR DESCRIPTION
`checkSignature` would be run with `:check` (since it was marked as a `property`) but then fail. `checkSignature` isn't meant to be used as a standalone property anyway, but rather as a building block for constructing other properties (e.g., `sampleVector`). Let's remove the `property` keyword to reflect this and fix `:check`.

Fixes https://github.com/GaloisInc/cryptol-specs/issues/334.