### PR TITLE
Add more specs to CI

### DIFF
--- a/cryproject.toml
+++ b/cryproject.toml
@@ -27,6 +27,12 @@ modules = [
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry",
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry",
 
+    # ML-DSA, omitting ML-DSA_87 because it takes a long time.
+    "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_44.cry",
+    "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_65.cry",
+    "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_44.cry",
+    "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_65.cry",
+
     # SHA1
     "Primitive/Keyless/Hash/SHA1/Specification.cry",
     "Primitive/Keyless/Hash/SHA1/Tests/*",

--- a/cryproject.toml
+++ b/cryproject.toml
@@ -66,12 +66,11 @@ modules = [
 
     # AES (key wrap and key wrap padded mode)
     "Primitive/Symmetric/Cipher/Block/Modes/Instantiations/AES256_KeyWrap.cry",
-    # Blocked by cryptol#1903
-    # "Primitive/Symmetric/Cipher/Block/Modes/Tests/AES256_KeyWrap*.cry",
+    "Primitive/Symmetric/Cipher/Block/Modes/Tests/AES256_KeyWrap*.cry",
 
-    # AES (XTS mode) -- blocked by cryptol#1903
-    # "Primitive/Symmetric/Cipher/Block/Modes/Instantiations/AES*_XTS.cry",
-    # "Primitive/Symmetric/Cipher/Block/Modes/Tests/AES*_XTS.cry",
+    # AES (XTS mode)
+    "Primitive/Symmetric/Cipher/Block/Modes/Instantiations/AES*_XTS.cry",
+    "Primitive/Symmetric/Cipher/Block/Modes/Tests/AES*_XTS.cry",
 
     # Simon
     "Primitive/Symmetric/Cipher/Block/Simon/Instantiations/*",

--- a/cryproject.toml
+++ b/cryproject.toml
@@ -13,6 +13,12 @@ modules = [
     "Primitive/Asymmetric/KEM/ECDH/Instantiations/*",
     "Primitive/Asymmetric/KEM/ECDH/Tests/*",
 
+    # ML-KEM
+    "Primitive/Asymmetric/KEM/ML_KEM/Instantiations/ML_KEM512.cry",
+    "Primitive/Asymmetric/KEM/ML_KEM/Instantiations/ML_KEM768.cry",
+    "Primitive/Asymmetric/KEM/ML_KEM/Instantiations/ML_KEM1024.cry",
+    "Primitive/Asymmetric/KEM/ML_KEM/Tests/*.cry",
+
     # ECDSA, instantiated with P-curves and SHA2
     "Primitive/Asymmetric/Signature/ECDSA/Instantiations/ECDSA_P224_SHA224.cry",
     "Primitive/Asymmetric/Signature/ECDSA/Instantiations/ECDSA_P256_SHA256.cry",


### PR DESCRIPTION
This adds several more existing gold-standard specs to the `cryproject.toml` file that is run by CI. In particular:
- XTS and AES key wrap modes have been unblocked with GaloisInc/cryptol#1903
- ML-KEM is fully added
- Most of the instantiations for ML-DSA are added. [A previous CI run timed out](https://github.com/GaloisInc/cryptol-specs/actions/runs/17743986804/job/50424627399) while running the most secure of these, ML-DSA-87, so I skipped it here to ensure we can finish adding the rest of the specs.

Reviewer requests: Make sure I typed all the file names correctly, and that CI runs successfully.

Mostly addresses, but does not complete #331