### PR TITLE
add ML-DSA-87 to CI

### DIFF
--- a/cryproject.toml
+++ b/cryproject.toml
@@ -27,11 +27,13 @@ modules = [
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry",
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry",
 
-    # ML-DSA, omitting ML-DSA_87 because it takes a long time.
+    # ML-DSA
     "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_44.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_65.cry",
+    "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_87.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_44.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_65.cry",
+    "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_87.cry",
 
     # SHA1
     "Primitive/Keyless/Hash/SHA1/Specification.cry",


### PR DESCRIPTION
With #336, closes #331.

This adds just ML-DSA-87 to CI. The docstrings on this take ages and require their own CI run to build.