### PR TITLE
Use `Option` in MEE-CBC

### DIFF
--- a/Primitive/Symmetric/Cipher/Authenticated/MEE_CBC.cry
+++ b/Primitive/Symmetric/Cipher/Authenticated/MEE_CBC.cry
@@ -1,5 +1,6 @@
 /**
  * @copyright Galois, Inc.
+ * @author Nichole Schimanski <nls@galois.com>
  */
 
 


### PR DESCRIPTION
MEE-CBC previously used the `(a, Bit)` anti-pattern. This commit fixes that to use the `Option` type instead.

This closes #239.