### PR TITLE
ci: update CI to handle partially-cached docstrings

### DIFF
--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -65,22 +65,28 @@ jobs:
 
       # Run the check-docstrings script, regardless of cache load.
       - name: "Run the check-docstrings script."
+        id: checkscript
         run: |
           git config --global --add safe.directory '*'
           echo "Check which caches exist, for sanity."
           gh cache list
 
           bash scripts/check_docstrings.sh .
+        # Timeout is slightly less than 6 hours to allow saving a cache in the case of timeout.
+        # The following steps don't run if this step failed, but do run if it was cancelled
+        # (e.g. due to hitting this timeout).
+        timeout-minutes: 355
+        continue-on-error: true
 
       # Caches can only be uploaded once. If we're on master and the cache already exists,
       # we need to delete it...
       - name: "If we're on master, delete the cache"
-        if: github.ref == 'refs/heads/master' && steps.load-cache.outputs.cache-hit == 'true'
+        if: github.ref == 'refs/heads/master' && steps.load-cache.outputs.cache-hit == 'true' && steps.checkscript.outcome != 'failure'
         run: gh cache delete ${{ env.CRYPTOL_CACHE_KEY }}
 
       # ...before we upload it. Do this regardless of whether it previously existed.
       - id: save-cache
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && steps.checkscript.outcome != 'failure'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.CRYPTOL_CACHE }}

--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -91,3 +91,10 @@ jobs:
         with:
           path: ${{ env.CRYPTOL_CACHE }}
           key: ${{ env.CRYPTOL_CACHE_KEY }}
+
+      # After potentially uploading the cache, we fail according to the checkscript step.
+      - name: "Check whether the script failed"
+        if: steps.checkscript.outcome != 'success'
+        run: |
+          echo "Docstrings script failed with ${{ steps.checkscript.outcome }}"
+          exit 1

--- a/cryproject.toml
+++ b/cryproject.toml
@@ -27,13 +27,11 @@ modules = [
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P256_SHA256.cry",
     "Primitive/Asymmetric/Signature/ECDSA/Tests/ECDSA_P384_SHA384.cry",
 
-    # ML-DSA
+    # ML-DSA (excluding the 87 parameter set, which takes too long to run)
     "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_44.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_65.cry",
-    "Primitive/Asymmetric/Signature/ML_DSA/Instantiations/ML_DSA_87.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_44.cry",
     "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_65.cry",
-    "Primitive/Asymmetric/Signature/ML_DSA/Tests/ML_DSA_87.cry",
 
     # SHA1
     "Primitive/Keyless/Hash/SHA1/Specification.cry",


### PR DESCRIPTION
This removes ML-DSA-87 from CI in an attempt to rebuild the cache, which was invalidated due to a change in the Cryptol prelude, and which takes longer than the maximum CI runtime of 4 hours to rebuild in its entirety.