### PR TITLE
ci: remove failure check from cache saving steps

### DIFF
--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -81,12 +81,12 @@ jobs:
       # Caches can only be uploaded once. If we're on master and the cache already exists,
       # we need to delete it...
       - name: "If we're on master, delete the cache"
-        if: github.ref == 'refs/heads/master' && steps.load-cache.outputs.cache-hit == 'true' && steps.checkscript.outcome != 'failure'
+        if: github.ref == 'refs/heads/master' && steps.load-cache.outputs.cache-hit == 'true'
         run: gh cache delete ${{ env.CRYPTOL_CACHE_KEY }}
 
       # ...before we upload it. Do this regardless of whether it previously existed.
       - id: save-cache
-        if: github.ref == 'refs/heads/master' && steps.checkscript.outcome != 'failure'
+        if: github.ref == 'refs/heads/master'
         uses: actions/cache/save@v4
         with:
           path: ${{ env.CRYPTOL_CACHE }}


### PR DESCRIPTION
I thought that a a timeout would result in the step outcome being "cancelled" (based on the messages in the UI) but it's actually "failure".

This provides a technical fix to address #342.

In total, the docstrings job takes about 12 hours to run from scratch: [see the three re-runs here; the first two time out and fail, but contribute toward the cache. The third passes](https://github.com/GaloisInc/cryptol-specs/actions/runs/20344997637). The expected workflow is that if the Cryptol prelude changes, we can re-run the job on main a few times to rebuild the cache. 

The linked action is from a branch that adds a debug step and lots a bunch of info. In particular, it adds a cache for that specific branch so I could test the retry logic. This branch only keeps the relevant change to the cache-saving job, so re-running the job will re-use the unchanged cache from `master` and won't result in a successful run.