### PR TITLE
Rearrange imports of parameter blocks and submodules

### DIFF
--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -57,13 +57,13 @@ jobs:
 
       # Check out the code.
       - id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # Pull the default cache
       - id: load-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.CRYPTOL_CACHE }}
           key: ${{ env.CRYPTOL_CACHE_KEY }}
@@ -100,7 +100,7 @@ jobs:
       # ...before we upload it. Do this regardless of whether it previously existed.
       - id: save-cache
         if: github.ref == 'refs/heads/master'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ env.CRYPTOL_CACHE }}
           key: ${{ env.CRYPTOL_CACHE_KEY }}

--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -33,6 +33,11 @@ jobs:
       # There's one cache for the whole repo. It's associated with the `master` branch.
       CRYPTOL_CACHE_KEY: cryptol-specs-cache
 
+      # Backup key, if we need to rebuild the cache from scratch on a branch.
+      # This is shared among all branches so it's not necessarily reliable.
+      # Only used when a branch has the `use-branch-cache` label.
+      BRANCH_CACHE_KEY: branch-cache
+
       # In order to use Github CLI in a workflow, we need
       # the token that is generated for this workflow.
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,6 +68,14 @@ jobs:
           path: ${{ env.CRYPTOL_CACHE }}
           key: ${{ env.CRYPTOL_CACHE_KEY }}
 
+      # Use branch cache
+      - id: load-branch-cache
+        uses: actions/cache/restore@v5
+        if: contains(github.event.pull_request.labels.*.name, 'use-branch-cache')
+        with:
+          path: ${{ env.CRYPTOL_CACHE }}
+          key: ${{ env.BRANCH_CACHE_KEY }}
+
       # Run the check-docstrings script, regardless of cache load.
       - name: "Run the check-docstrings script."
         id: checkscript
@@ -91,6 +104,20 @@ jobs:
         with:
           path: ${{ env.CRYPTOL_CACHE }}
           key: ${{ env.CRYPTOL_CACHE_KEY }}
+
+      # If we used a branch cache, delete and re-upload it.
+      - name: "If we used a branch cache, delete it"
+        if: |
+          github.ref != 'refs/heads/master' &&
+          contains(github.event.pull_request.labels.*.name, 'use-branch-cache') &&
+          steps.load-branch-cache.outputs.cache-hit == 'true'
+        run: gh cache delete ${{ env.BRANCH_CACHE_KEY }}
+      - name: "Re-upload branch cache"
+        if: contains(github.event.pull_request.labels.*.name, 'use-branch-cache')
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ env.CRYPTOL_CACHE }}
+          key: ${{ env.BRANCH_CACHE_KEY }}
 
       # After potentially uploading the cache, we fail according to the checkscript step.
       - name: "Check whether the script failed"

--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -108,7 +108,6 @@ jobs:
       # If we used a branch cache, delete and re-upload it.
       - name: "If we used a branch cache, delete it"
         if: |
-          github.ref != 'refs/heads/master' &&
           contains(github.event.pull_request.labels.*.name, 'use-branch-cache') &&
           steps.load-branch-cache.outputs.cache-hit == 'true'
         run: gh cache delete ${{ env.BRANCH_CACHE_KEY }}

--- a/Primitive/Asymmetric/KEM/ML_KEM/Specification.cry
+++ b/Primitive/Asymmetric/KEM/ML_KEM/Specification.cry
@@ -81,6 +81,77 @@ private
  */
 type Byte = [8]
 
+parameter
+    /*
+     * The parameter `k` determines the dimensions of the encryption key matrix
+     * and the secret and noise vectors created and used in key generation and
+     * encryption.
+     * [FIPS-203] Section 8.
+     *
+     * The constraint on the width of `k` is drawn from `K-PKE-KeyGen`. In
+     * that function, the variable `N` varies from 0 to `2k` and is passed as
+     * the second parameter to the `PRF` function. `PRF` restricts the second
+     * parameter to be exactly 1 byte. Therefore, `2k` must fit into a byte.
+     * [FIPS-203] Section 5.1 Algorithm 13 (see lines 2 and 8-15) and Section
+     * 4.1 Equation 4.2.
+     */
+    type k : #
+    type constraint (width k > 0, width (2*k) <= 8)
+
+    /*
+     * The parameter `eta_1` specifies the distribution from which the secret
+     * vectors are drawn in key generation and encryption.
+     * [FIPS-203] Section 8.
+     *
+     * eta_1 must be in the set {2, 3} for use in a PRF and to parameterize
+     * sampling from the centered binomial distribution.
+     * [FIPS-203] Section 4.1 "Pseudorandom Function" and Section 4.2.2
+     * "Sampling from the centered binomial distribution"
+     */
+    type eta_1 : #
+    type constraint (fin eta_1, 2 <= eta_1, eta_1 <= 3)
+
+    /*
+     * The parameter eta_2 is required to specify the distribution from which
+     * the noise vectors are drawn in encryption.
+     * [FIPS-203] Section 8.
+     *
+     * eta_2 must be in the set {2, 3} for use in a PRF and to parameterize
+     * sampling from the centered binomial distribution.
+     * [FIPS-203] Section 4.1 "Pseudorandom Function" and Section 4.2.2
+     * "Sampling from the centered binomial distribution"
+     */
+    type eta_2 : #
+    type constraint (fin eta_2, 2 <= eta_2, eta_2 <= 3)
+
+    /*
+     * The parameter `d_u` is a parameter and input for the compression and
+     * encoding functions.
+     * [FIPS-203] Section 8.
+     *
+     * For compression, `d_u` must be smaller than the bit length of `q` (fixed
+     * to 12).
+     * [FIPS-203] Section 4.2.1 "Compression and decompression".
+     * For encoding, the valid range of values for `d_u` is `1 ≤ d_u ≤ 12`.
+     * [FIPS-203] Section 4.2.1 "Encoding and decoding".
+     */
+    type d_u : #
+    type constraint (fin d_u, d_u < 12, d_u > 0)
+
+    /*
+     * The parameter `d_v` is a parameter and input for the compression and
+     * encoding functions.
+     * [FIPS-203] Section 8.
+     *
+     * For compression, `d_v` must be smaller than the bit length of `q` (fixed
+     * to 12).
+     * [FIPS-203] Section 4.2.1 "Compression and decompression".
+     * For encoding, the valid range of values for `d_v` is `1 ≤ d_v ≤ 12`.
+     * [FIPS-203] Section 4.2.1 "Encoding and decoding".
+     */
+    type d_v : #
+    type constraint (fin d_v, d_v < 12, d_v > 0)
+
 private
     /**
      * An element in the ring `R_q`.
@@ -714,7 +785,6 @@ private
  * prove mathematical equivalence.
  * [FIPS-203] Introduction, "7. Implementations".
  */
-import submodule NTT
 submodule NTT where
     private
         /**
@@ -1019,6 +1089,7 @@ submodule NTT where
         [k1][k2]Tq -> [k2][k3]Tq -> [k1][k3]Tq
     dotMatMat matrix1 matrix2 = transpose [dotMatVec matrix1 vector | vector <- m']
         where m' = transpose matrix2
+import submodule NTT
 
 /**
  * The K-PKE component scheme.
@@ -1422,74 +1493,3 @@ private
  */
 Decaps : DecapsulationKey -> Ciphertext -> SharedSecretKey
 Decaps = Decaps_internal
-
-parameter
-    /*
-     * The parameter `k` determines the dimensions of the encryption key matrix
-     * and the secret and noise vectors created and used in key generation and
-     * encryption.
-     * [FIPS-203] Section 8.
-     *
-     * The constraint on the width of `k` is drawn from `K-PKE-KeyGen`. In
-     * that function, the variable `N` varies from 0 to `2k` and is passed as
-     * the second parameter to the `PRF` function. `PRF` restricts the second
-     * parameter to be exactly 1 byte. Therefore, `2k` must fit into a byte.
-     * [FIPS-203] Section 5.1 Algorithm 13 (see lines 2 and 8-15) and Section
-     * 4.1 Equation 4.2.
-     */
-    type k : #
-    type constraint (width k > 0, width (2*k) <= 8)
-
-    /*
-     * The parameter `eta_1` specifies the distribution from which the secret
-     * vectors are drawn in key generation and encryption.
-     * [FIPS-203] Section 8.
-     *
-     * eta_1 must be in the set {2, 3} for use in a PRF and to parameterize
-     * sampling from the centered binomial distribution.
-     * [FIPS-203] Section 4.1 "Pseudorandom Function" and Section 4.2.2
-     * "Sampling from the centered binomial distribution"
-     */
-    type eta_1 : #
-    type constraint (fin eta_1, 2 <= eta_1, eta_1 <= 3)
-
-    /*
-     * The parameter eta_2 is required to specify the distribution from which
-     * the noise vectors are drawn in encryption.
-     * [FIPS-203] Section 8.
-     *
-     * eta_2 must be in the set {2, 3} for use in a PRF and to parameterize
-     * sampling from the centered binomial distribution.
-     * [FIPS-203] Section 4.1 "Pseudorandom Function" and Section 4.2.2
-     * "Sampling from the centered binomial distribution"
-     */
-    type eta_2 : #
-    type constraint (fin eta_2, 2 <= eta_2, eta_2 <= 3)
-
-    /*
-     * The parameter `d_u` is a parameter and input for the compression and
-     * encoding functions.
-     * [FIPS-203] Section 8.
-     *
-     * For compression, `d_u` must be smaller than the bit length of `q` (fixed
-     * to 12).
-     * [FIPS-203] Section 4.2.1 "Compression and decompression".
-     * For encoding, the valid range of values for `d_u` is `1 ≤ d_u ≤ 12`.
-     * [FIPS-203] Section 4.2.1 "Encoding and decoding".
-     */
-    type d_u : #
-    type constraint (fin d_u, d_u < 12, d_u > 0)
-
-    /*
-     * The parameter `d_v` is a parameter and input for the compression and
-     * encoding functions.
-     * [FIPS-203] Section 8.
-     *
-     * For compression, `d_v` must be smaller than the bit length of `q` (fixed
-     * to 12).
-     * [FIPS-203] Section 4.2.1 "Compression and decompression".
-     * For encoding, the valid range of values for `d_v` is `1 ≤ d_v ≤ 12`.
-     * [FIPS-203] Section 4.2.1 "Encoding and decoding".
-     */
-    type d_v : #
-    type constraint (fin d_v, d_v < 12, d_v > 0)

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_parameterized.cry
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_parameterized.cry
@@ -4,6 +4,8 @@
  */
 module falcon_parameterized where
 
+import Float
+
 parameter
     type _k : #
     type _n : #
@@ -380,7 +382,6 @@ BaseSampler : [72] -> ZZ
 BaseSampler(u) = z0 where
     z0 = zero
 
-import Float
 ApproxExp : (Float64, Float64) -> [64]
 ApproxExp(x, ccs) = y'' where
     C = [

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/spec2.tex
@@ -56,10 +56,27 @@ coefficients. The degree $n$ is normally a power of two (typically 512 or
 $\phi$ (which is always of the form $\phi = x^n + 1$).
 
 \begin{code}
-  parameter
     type _k : #
     type _n : #
     type constraint (fin _k, _n == 2^^_k, _k > 0)
+
+    // This type comes from the "quotient rings" section below.
+    type q : #
+    type constraint (fin q, q > 0, q <= 2 ^^ 16, width q >= 7,
+                 prime q, Literal q (Float 11 53), q >= _n+1)
+
+    // These come from the section "Public Parameters" below.
+    sigma : Float64
+    type sbytelen : #
+    type constraint (fin sbytelen)
+
+    // This comes from the NTT section below.
+    r : Z q
+
+    // These types come from the "recommended parameters" section below.
+    sigma_min : Float64
+    sigma_max : Float64
+    beta : Integer
 
   type Poly degree a = [degree]a
   type ZZ = Integer
@@ -177,12 +194,12 @@ On one hand, classical algebraic operations in the field $\bQ[x]/(x^{n} + 1)$ ar
 \paragraph{Matrices, vectors and scalars.} Matrices will usually be in bold uppercase (e.g. $\matB$), vectors in bold lowercase (e.g. $\vecv$) and scalars -- which include polynomials -- in italic (e.g. $s$). We use the row convention for vectors. The transpose of a matrix $\matB$ may be noted $\matB^\t$. It is to be noted that for a polynomial $f$, we do \emph{not} use $f'$ to denote its derivative in this document.
 
 \paragraph{Quotient rings.} For $q \in \bN^\star$, we denote by $\bZ_q$ the quotient ring $\bZ/q\bZ$. In \falcon, our integer modulus $q = 12289$ is prime so $\bZ_q$ is also a finite field. We denote by $\bZ_q^\times$ the group of invertible elements of $\bZ_q$, and by $\varphi$ Euler's totient function: $\varphi(q) = |\bZ_q^\times| = q - 1 = 3 \cdot 2^{12}$ since $q$ is prime.
-\begin{code}
-  parameter
-    type q : #
-    type constraint (fin q, q > 0, q <= 2 ^^ 16, width q >= 7,
-                     prime q, Literal q (Float 11 53), q >= _n+1)
-\end{code}
+%\begin{code}
+%  parameter
+%    type q : #
+%    type constraint (fin q, q > 0, q <= 2 ^^ 16, width q >= 7,
+%                     prime q, Literal q (Float 11 53), q >= _n+1)
+%\end{code}
 
 
 \paragraph{Number fields.} \falcon uses a polynomial modulus $\phi = x^n+1$ (for $n = 2^\kappa$). It is a monic polynomial of $\bZ[x]$, irreducible in $\bQ[x]$ and with distinct roots over $\bC$.
@@ -312,12 +329,12 @@ For clarity, public parameters may be omitted (\eg in algorithms' headers) when 
 % $q$ such that $q$ is prime and $q = 1 \bmod 2n$; for $n\leq 1024$, $q =
 % 18433$ is such an alternate modulus value.
 
-\begin{code}
-  parameter
-    sigma : Float64
-    type sbytelen : #
-    type constraint (fin sbytelen)
-\end{code}
+%\begin{code}
+%  parameter
+%    sigma : Float64
+%    type sbytelen : #
+%    type constraint (fin sbytelen)
+%\end{code}
 
 \subsection{Private Key}
 
@@ -637,8 +654,8 @@ The \falcon public key \pk corresponding to the private key $\sk =
 
 \begin{code}
   /* Recursive NTT */
-  parameter
-    r : Z q
+  //parameter
+  //  r : Z q
 
   roots : [inf](Z q)
   roots = iterate ((*) (r * r)) 1
@@ -2376,12 +2393,12 @@ We specify two sets of parameters that address security levels I and V as define
 	\caption{\falcon parameter sets.}\label{tab:falconparam}
 \end{table}
 
-\begin{code}
-  parameter
-    sigma_min : Float64
-    sigma_max : Float64
-    beta : Integer
-\end{code}
+%\begin{code}
+%  parameter
+%    sigma_min : Float64
+%    sigma_max : Float64
+%    beta : Integer
+%\end{code}
 
 \tprcomment{I commented the paragraph on the acceptance bound}
 %\paragraph{Acceptance bound.} It is important that signers and verifiers

--- a/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
+++ b/Primitive/Asymmetric/Signature/ML_DSA/Specification.cry
@@ -27,6 +27,9 @@ module Primitive::Asymmetric::Signature::ML_DSA::Specification where
 import Primitive::Keyless::Hash::SHA3::Instantiations::SHAKE128 as SHAKE128
 import Primitive::Keyless::Hash::SHA3::Instantiations::SHAKE256 as SHAKE256
 
+// [FIPS-204] Section 4 is largely defined in this interface.
+import interface Primitive::Asymmetric::Signature::ML_DSA::Parameters
+
 /**
  * The set {0, 1, ..., 255} of integers represented by a byte, denoted 𝔹 in
  * the spec.
@@ -184,9 +187,6 @@ HBits str = split (SHAKE256::xof`{8 * l} (str))
  */
 G : {l, m} (fin m) => [m][8] -> [l][8]
 G str = SHAKE128::xofBytes`{8 * l} str
-
-// [FIPS-204] Section 4 is largely defined in this interface.
-import interface Primitive::Asymmetric::Signature::ML_DSA::Parameters
 
 /**
  * A 512th root of unity in `Z_q`.

--- a/Primitive/Asymmetric/Signature/SphincsPlus/3.1/specification.tex
+++ b/Primitive/Asymmetric/Signature/SphincsPlus/3.1/specification.tex
@@ -190,6 +190,53 @@ data types or structures.
   parameter
     type Byte = [8]
 
+    // This is from section "tweakable hash functions"
+    T : {l} (fin l) => ([n]Byte, [32]Byte, [l*n]Byte) -> [n]Byte
+
+    // This is from section "PRF and Message digest"
+    PRF : ([n]Byte, [32]Byte) -> [n]Byte
+    PRF_msg : {lmsg} (fin lmsg) => ([n]Byte, [n]Byte, [lmsg]Byte) -> [n]Byte
+    H_msg : {lmsg} (fin lmsg) =>
+      ([n]Byte, [n]Byte, [n]Byte, [lmsg]Byte) -> [m]Byte
+
+    // This is from section "wotsp parameters"
+    type n : #
+    type constraint (fin n, n > 0)
+
+    // we define loglogw as the parameter since
+    // w can only take the values 4,16,256
+    type loglogw : #
+    type constraint (loglogw >= 1, loglogw <= 3)
+
+    // This is from section "FORS: Forest of random subsets"
+    type t : #
+    type constraint (fin t, t >= 1)
+    type logt : #
+    type constraint (logt == a)
+    type FORSMessage = [k * a]Bit
+    type FORSPrKey = [k * t][n]Byte
+    type FORSPbKey = [n]Byte
+
+    // These are from sections "SPX Parameters"
+    type h : #
+    type constraint (fin h)
+    type d : #
+    type constraint (fin d, d >= 2, h%d == 0, h/d >= 1)
+    // the following constraint is needed because
+    // h - h/d bits should define a tree address
+    type constraint (3*4*8 >= h - h/d)
+    type k : #
+    type constraint (fin k, k >= 1)
+    // instead of t, we consider a = log t as the parameter since
+    // it is a that is instantiated.
+    type a : #
+    type constraint (fin a, a >= 1)
+
+    type m : #
+    type constraint (m == (k*logt+7)/8 + (h-h/d+7)/8 + (h/d+7)/8)
+
+
+
   property ByteLength = length (groupBy`{8} 0xe534f0) == 3
 \end{code}
 
@@ -420,10 +467,10 @@ base_w(X, w, out_len) {
    The function $\sphincsT_\ell$ is denoted by \texttt{T\_l} in pseudocode.
    %\TODO{Check this again if we change addresses --> We agreed on 32byte addresses, so we are fine.}
 
-\begin{code}
-  parameter
-    T : {l} (fin l) => ([n]Byte, [32]Byte, [l*n]Byte) -> [n]Byte
-\end{code}
+%\begin{code}
+%  parameter
+%    T : {l} (fin l) => ([n]Byte, [32]Byte, [l*n]Byte) -> [n]Byte
+%\end{code}
 
    There are two special cases which we rename for consistency with previous
    descriptions of hash-based signature schemes:
@@ -462,13 +509,13 @@ base_w(X, w, out_len) {
 %    \TODO{Verify required key and output length.}
 %    \TODO{$m$ is only defined in the FORS section. In practice this also includes a bit of rounding to bytes, as well, and we also want to pull the leaf index from this output. -Joost}
 
-\begin{code}
-  parameter
-    PRF : ([n]Byte, [32]Byte) -> [n]Byte
-    PRF_msg : {lmsg} (fin lmsg) => ([n]Byte, [n]Byte, [lmsg]Byte) -> [n]Byte
-    H_msg : {lmsg} (fin lmsg) =>
-      ([n]Byte, [n]Byte, [n]Byte, [lmsg]Byte) -> [m]Byte
-\end{code}
+%\begin{code}
+%  parameter
+%    PRF : ([n]Byte, [32]Byte) -> [n]Byte
+%    PRF_msg : {lmsg} (fin lmsg) => ([n]Byte, [n]Byte, [lmsg]Byte) -> [n]Byte
+%    H_msg : {lmsg} (fin lmsg) =>
+%      ([n]Byte, [n]Byte, [n]Byte, [lmsg]Byte) -> [m]Byte
+%\end{code}
 
 \subsubsection{Hash Function Address Scheme (Structure of \adrs)}\label{prelim:addresses}
 
@@ -755,14 +802,14 @@ These parameters are summarized as follows:
 \end{itemize}
 
 \begin{code}
-  parameter
-    type n : #
-    type constraint (fin n, n > 0)
+//  parameter
+//    type n : #
+//    type constraint (fin n, n > 0)
 
     // we define loglogw as the parameter since
     // w can only take the values 4,16,256
-    type loglogw : #
-    type constraint (loglogw >= 1, loglogw <= 3)
+//    type loglogw : #
+//    type constraint (loglogw >= 1, loglogw <= 3)
 
   type logw = 2^^loglogw
   type w = 2^^logw
@@ -1942,16 +1989,16 @@ $i$th private key element of the first set gets selected and so on. The signatur
 consists of the selected private key elements and the associated authentication
 paths.
 
-\begin{code}
-  parameter
-    type t : #
-    type constraint (fin t, t >= 1)
-    type logt : #
-    type constraint (logt == a)
-    type FORSMessage = [k * a]Bit
-    type FORSPrKey = [k * t][n]Byte
-    type FORSPbKey = [n]Byte
-\end{code}
+%\begin{code}
+%  parameter
+%    type t : #
+%    type constraint (fin t, t >= 1)
+%    type logt : #
+%    type constraint (logt == a)
+%    type FORSMessage = [k * a]Bit
+%    type FORSPrKey = [k * t][n]Byte
+%    type FORSPbKey = [n]Byte
+%\end{code}
 
 \spx uses implicit verification for \fors, only using a method to compute
 a candidate public key from a signature. This is done by computing root nodes
@@ -2347,22 +2394,22 @@ generation.
  \item  $t$ : the number of leaves of a \fors tree as defined in \autoref{sec:fors:params}.
 \end{description}
 
-\begin{code}
-  parameter
-    type h : #
-    type constraint (fin h)
-    type d : #
-    type constraint (fin d, d >= 2, h%d == 0, h/d >= 1)
-    // the following constraint is needed because
-    // h - h/d bits should define a tree address
-    type constraint (3*4*8 >= h - h/d)
-    type k : #
-    type constraint (fin k, k >= 1)
-    // instead of t, we consider a = log t as the parameter since
-    // it is a that is instantiated.
-    type a : #
-    type constraint (fin a, a >= 1)
-\end{code}
+%\begin{code}
+%  parameter
+%    type h : #
+%    type constraint (fin h)
+%    type d : #
+%    type constraint (fin d, d >= 2, h%d == 0, h/d >= 1)
+%    // the following constraint is needed because
+%    // h - h/d bits should define a tree address
+%    type constraint (3*4*8 >= h - h/d)
+%    type k : #
+%    type constraint (fin k, k >= 1)
+%    // instead of t, we consider a = log t as the parameter since
+%    // it is a that is instantiated.
+%    type a : #
+%    type constraint (fin a, a >= 1)
+%\end{code}
 
 All the restrictions stated in the previous sections apply. Recall that
 we use $a = \log t$. Moreover, from these values the values $m$ and \len are
@@ -2372,11 +2419,11 @@ computed as
   It is computed as
   $$m=\floor{(k\log t +7)/ 8} + \floor{(h - h/d +7)/ 8} + \floor{(h / d +7)/ 8}.$$
 
-\begin{code}
-  parameter
-    type m : #
-    type constraint (m == (k*logt+7)/8 + (h-h/d+7)/8 + (h/d+7)/8)
-\end{code}
+%\begin{code}
+%  parameter
+%    type m : #
+%    type constraint (m == (k*logt+7)/8 + (h-h/d+7)/8 + (h/d+7)/8)
+%\end{code}
 
   While only $h + k\log t$ bits would be needed, using the longer $m$ as defined
   above simplifies implementations significantly.

--- a/Primitive/Keyless/Hash/SHA2Internal/SHA.cry
+++ b/Primitive/Keyless/Hash/SHA2Internal/SHA.cry
@@ -22,9 +22,6 @@ module Primitive::Keyless::Hash::SHA2Internal::SHA where
 import Array
 import Common::ByteArray
 
-sha : {L} (2 * w >= width L) => [L] -> [digest_size]
-sha M = take (join (SHA_2_Common' [ split x | x <- parse`{num_blocks L} (pad`{L} M) ]))
-
 parameter
 
   /** Word size
@@ -57,6 +54,9 @@ parameter
   SIGMA_1 : [wp] -> [wp]
   sigma_0 : [wp] -> [wp]
   sigma_1 : [wp] -> [wp]
+
+sha : {L} (2 * w >= width L) => [L] -> [digest_size]
+sha M = take (join (SHA_2_Common' [ split x | x <- parse`{num_blocks L} (pad`{L} M) ]))
 
 // Export some of the parameters
 SHAH0 = H0

--- a/Primitive/Keyless/Hash/SHA3/SHA3.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3.cry
@@ -13,10 +13,6 @@
  */
 module Primitive::Keyless::Hash::SHA3::SHA3 where
 import Primitive::Keyless::Hash::SHA3::KeccakBitOrdering as KBO
-import Primitive::Keyless::Hash::SHA3::Specification where
-    type b = 1600
-    type nr = 24
-    type c = 2 * digest
 
 parameter
     /**
@@ -29,6 +25,11 @@ parameter
      */
     type digest : #
     type constraint (fin digest, digest % 8 == 0, digest >= 224, digest <= 512)
+
+import Primitive::Keyless::Hash::SHA3::Specification where
+    type b = 1600
+    type nr = 24
+    type c = 2 * digest
 
 /**
  * Length of the hash digest.


### PR DESCRIPTION
Closes #344.

I think this might be a little tricky CI-wise: the Cryptol update made some of these files invalid / unable to load. I think it also updated the Cryptol prelude, which invalidates the cache. Recently, we fixed CI to be able to handle a Cryptol prelude update on main by rebuilding the cache over a couple of CI runs. However, this assumed that we could actually run on main. Briefly:
- main's cache is broken
- This branch needs main's cache to run the docstrings within the time limit
- main's cache won't get fixed until this branch is merged

I checked the docstrings on some of the affected files locally, using Cryptol nightly (version 3.5.0.99 ([d3027bc](https://github.com/GaloisInc/cryptol/commit/d3027bc5230c531046756fff78760b8b8147de95))) on the instantiation and tests for: ML-KEM 512, SHA3-256, SHAKE128, and ML-DSA44, so I think this will be ultimately pass.