### PR TITLE
Update and simplify CI

### DIFF
--- a/.github/workflows/check_docstrings.yml
+++ b/.github/workflows/check_docstrings.yml
@@ -57,7 +57,7 @@ jobs:
 
       # Check out the code.
       - id: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       options: --user root
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Cryptol Version
       run: cryptol --version

--- a/.github/workflows/copyright_check.yml
+++ b/.github/workflows/copyright_check.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: "Run copyright script"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,22 +6,14 @@ jobs:
   build:
     name: Lint
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: read
-      statuses: write
+    container: mstruebing/editorconfig-checker:latest
 
     steps:
-      - name: Checkout code
+      - name: Check out code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-
-      - name: Whitespace check
-        uses: super-linter/super-linter/slim@v8.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Explicitly enabling this linter causes super-linter to disable
-          # all other linters.
-          VALIDATE_EDITORCONFIG: true
+      - name: Check whitespace
+        run: |
+          test -f .editorconfig
+          ec

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check whitespace


### PR DESCRIPTION
This addresses two maintenance issues for the CI:
1. Replaces superlinter, and its use of a highly-permissioned `GITHUB_TOKEN`, with direct use of the editorconfig tool, which is the only one we're using out of the many provided by superlinter. This removes the pretty-printed checkbox from the action, which seems fine to me.
2. Updates all the checkout actions to the latest version.

[Here's a sample run](https://github.com/GaloisInc/cryptol-specs/actions/runs/23349380464/job/67923511625) where I introduced poorly-linted code.

Closes https://github.com/GaloisInc/cryptol-specs/security/dependabot/1. 