### PR TITLE
`falcon`: Directly instantiate `spec2` #357

### DIFF
--- a/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_1024.cry
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_1024.cry
@@ -2,10 +2,7 @@
  * @copyright Galois, Inc
  * @author Marios Georgiou <marios@galois.com>
  */
-module falcon_1024 where
-
-submodule falcon_inst = spec2
-    where
+module falcon_1024 = spec2 where
     type _k = 10
     type _n = 1024
     type pkbytelen = 1793
@@ -1044,5 +1041,3 @@ submodule falcon_inst = spec2
         (0.9999247018391445, -0.012271538285720572),
         (0.9999811752826011, -0.006135884649154477)
     ]
-
-import submodule falcon_inst

--- a/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_512.cry
+++ b/Primitive/Asymmetric/Signature/FALCON/1.2/falcon_512.cry
@@ -2,10 +2,7 @@
  * @copyright Galois, Inc
  * @author Marios Georgiou <marios@galois.com>
  */
-module falcon_512 where
-
-submodule falcon_inst = spec2
-    where
+module falcon_512 = spec2 where
     type _k = 9
     type _n = 512
     type pkbytelen = 897
@@ -532,5 +529,3 @@ submodule falcon_inst = spec2
         (0.9996988186962042, -0.02454122852291245),
         (0.9999247018391445, -0.012271538285720572)
     ]
-
-import submodule falcon_inst


### PR DESCRIPTION
This makes `falcon_{512,1024}` directly instantiate `spec2` rather than instantiating `spec2` indirectly via a submodule.

Fixes #357.