### PR TITLE
SHA3: Explicitly name the underlying Keccak instance

### DIFF
--- a/Primitive/Keyless/Hash/SHA3/SHA3.cry
+++ b/Primitive/Keyless/Hash/SHA3/SHA3.cry
@@ -26,10 +26,12 @@ parameter
     type digest : #
     type constraint (fin digest, digest % 8 == 0, digest >= 224, digest <= 512)
 
-import Primitive::Keyless::Hash::SHA3::Specification where
+submodule Keccak = Primitive::Keyless::Hash::SHA3::Specification where
     type b = 1600
     type nr = 24
     type c = 2 * digest
+
+import submodule Keccak (Keccak)
 
 /**
  * Length of the hash digest.


### PR DESCRIPTION
This enables external verification in to access the underlying Keccak primitives as used in a SHA3 instantiation. In particular this support compositional verification activities against refined specifications.