### PR TITLE
Fix linting and typechecking CI jobs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,17 +3,15 @@ name: Lint
 on: [push, pull_request]
 
 jobs:
-  build:
+  lint:
     name: Lint
     runs-on: ubuntu-latest
-    container: mstruebing/editorconfig-checker:latest
 
     steps:
       - name: Check out code
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
       - name: Check whitespace
-        run: |
-          test -f .editorconfig
-          ec
+        uses: docker://mstruebing/editorconfig-checker:latest


### PR DESCRIPTION
This fixes two broken CI jobs: linting and typechecking.

Linting: Not quite sure why this broke, but a new version of the editorconfig Docker container started failing. I'm guessing they removed the direct installation of the `ec` command. This modifies the CI job to sort of call the container as a step rather than running entirely within it.

Here's [a sample run](https://github.com/GaloisInc/cryptol-specs/actions/runs/34268130122) where it fails when I manually add linting errors.

Typechecking: A new timeout for the solver wasn't letting through some of the more complex (but correct) specs, specifically the sphincs+ ones. I modified the timeout in the script used for the CI job to be larger (30s) than the default (5s) and it seems to be plenty big enough.